### PR TITLE
Add reload button to ChatGPT based response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "llm-plugin",
-	"version": "0.17.0",
+	"version": "0.17.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "llm-plugin",
-			"version": "0.17.0",
+			"version": "0.17.1",
 			"license": "MIT",
 			"dependencies": {
 				"openai": "^4.28.0"

--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -332,9 +332,9 @@ export class ChatContainer {
 		this.loadingDivContainer = this.historyMessages.createDiv();
 		const loadingIcon = this.loadingDivContainer.createDiv();
 		this.streamingDiv = this.loadingDivContainer.createDiv();
-		const addText = new ButtonComponent(this.loadingDivContainer);
-		addText.setIcon("files");
-		addText.buttonEl.addClass("add-text", "hide");
+		const copyToClipboardButton = new ButtonComponent(this.loadingDivContainer);
+		copyToClipboardButton.setIcon("files");
+		copyToClipboardButton.buttonEl.addClass("add-text", "hide");
 		streaming
 			? (this.streamingDiv.innerHTML = "")
 			: (this.streamingDiv.innerHTML = `<span class="bouncing-dots"><span class="dot">.</span><span class="dot">.</span><span class="dot">.</span></span>`);
@@ -349,15 +349,15 @@ export class ChatContainer {
 
 		if (streaming) {
 			this.loadingDivContainer.addEventListener("mouseenter", () => {
-				addText.buttonEl.removeClass("hide");
+				copyToClipboardButton.buttonEl.removeClass("hide");
 			});
 
 			this.loadingDivContainer.addEventListener("mouseleave", () => {
-				addText.buttonEl.addClass("hide");
+				copyToClipboardButton.buttonEl.addClass("hide");
 			});
 		}
 
-		addText.onClick(async () => {
+		copyToClipboardButton.onClick(async () => {
 			await navigator.clipboard.writeText(this.previewText);
 			new Notice("Text copied to clipboard");
 		});
@@ -390,9 +390,9 @@ export class ChatContainer {
 		const imLikeMessageContainer = this.historyMessages.createDiv();
 		const icon = imLikeMessageContainer.createDiv();
 		const imLikeMessage = imLikeMessageContainer.createDiv();
-		const addText = new ButtonComponent(imLikeMessageContainer);
+		const copyToClipboardButton = new ButtonComponent(imLikeMessageContainer);
 
-		addText.setIcon("files");
+		copyToClipboardButton.setIcon("files");
 		icon.innerHTML = role[0];
 		// imLikeMessage.innerHTML = content;
 		MarkdownRenderer.render(
@@ -409,7 +409,7 @@ export class ChatContainer {
 			item.setAttribute("style", "display: none");
 		});
 		imLikeMessageContainer.addClass("im-like-message-container", "flex");
-		addText.buttonEl.addClass("add-text", "hide");
+		copyToClipboardButton.buttonEl.addClass("add-text", "hide");
 		icon.addClass("message-icon");
 		imLikeMessage.addClass(
 			"im-like-message",
@@ -422,15 +422,15 @@ export class ChatContainer {
 		}
 
 		imLikeMessageContainer.addEventListener("mouseenter", () => {
-			addText.buttonEl.removeClass("hide");
+			copyToClipboardButton.buttonEl.removeClass("hide");
 		});
 
 		imLikeMessageContainer.addEventListener("mouseleave", () => {
-			addText.buttonEl.addClass("hide");
+			copyToClipboardButton.buttonEl.addClass("hide");
 		});
 
-		addText.setTooltip("Copy to clipboard");
-		addText.onClick(async () => {
+		copyToClipboardButton.setTooltip("Copy to clipboard");
+		copyToClipboardButton.onClick(async () => {
 			await navigator.clipboard.writeText(content);
 			new Notice("Text copied to clipboard");
 		});

--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -75,11 +75,7 @@ export class ChatContainer {
 	}
 
 	async regenerateOutput() {
-		// Rm the most recent assistant message
-		this.messages.pop()
-		const lastUserMessage = this.messages[this.messages.length-1]
-		// TODO - Delete the last message on the ui
-		// this.historyPop()
+		this.removeLastMessageAndHistoryMessage()
 		// TODO - do not copy paste && support more than chatgpt
 		const API_KEY = this.plugin.settings.openAIAPIKey;
 		if (!API_KEY) {
@@ -121,8 +117,6 @@ export class ChatContainer {
 				role: "assistant",
 				content: this.previewText,
 			});
-			console.log("what are our params", params)
-			this.historyPush(params as ChatHistoryItem);
 		}
 	}
 
@@ -521,10 +515,13 @@ export class ChatContainer {
 
 		this.createMessage(role, content, length);
 	}
-
-	removeMessage(header: Header, modelName: string) {
+	removeLastMessageAndHistoryMessage() {
 		this.messages.pop();
 		this.historyMessages.lastElementChild?.remove();
+	}
+
+	removeMessage(header: Header, modelName: string) {
+		this.removeLastMessageAndHistoryMessage()
 		if (this.historyMessages.children.length < 1) {
 			header.setHeader(modelName, "LLM Plugin");
 		}

--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -392,7 +392,7 @@ export class ChatContainer {
 		refreshButton.setIcon("refresh-cw");
 
 		copyToClipboardButton.buttonEl.addClass("add-text", "hide");
-		refreshButton.buttonEl.addClass("add-text", "hide");
+		refreshButton.buttonEl.addClass("refresh-output", "hide");
 
 		streaming
 			? (this.streamingDiv.innerHTML = "")

--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -76,12 +76,11 @@ export class ChatContainer {
 
 	async regenerateOutput() {
 		this.removeLastMessageAndHistoryMessage()
-		// TODO - do not copy paste && support more than chatgpt
 		this.handleGenerate()
 	}
 
 	async handleGenerate() {
-		// TODO - do not copy paste && support more than chatgpt
+		// TODO - support more than chatgpt
 
 		this.previewText = "";
 		const { model, endpointURL, modelEndpoint } =

--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -332,9 +332,16 @@ export class ChatContainer {
 		this.loadingDivContainer = this.historyMessages.createDiv();
 		const loadingIcon = this.loadingDivContainer.createDiv();
 		this.streamingDiv = this.loadingDivContainer.createDiv();
+
 		const copyToClipboardButton = new ButtonComponent(this.loadingDivContainer);
 		copyToClipboardButton.setIcon("files");
+
+		const refreshButton = new ButtonComponent(this.loadingDivContainer);
+		refreshButton.setIcon("refresh-cw");
+
 		copyToClipboardButton.buttonEl.addClass("add-text", "hide");
+		refreshButton.buttonEl.addClass("add-text", "hide");
+
 		streaming
 			? (this.streamingDiv.innerHTML = "")
 			: (this.streamingDiv.innerHTML = `<span class="bouncing-dots"><span class="dot">.</span><span class="dot">.</span><span class="dot">.</span></span>`);
@@ -350,10 +357,12 @@ export class ChatContainer {
 		if (streaming) {
 			this.loadingDivContainer.addEventListener("mouseenter", () => {
 				copyToClipboardButton.buttonEl.removeClass("hide");
+				refreshButton.buttonEl.removeClass("hide");
 			});
 
 			this.loadingDivContainer.addEventListener("mouseleave", () => {
 				copyToClipboardButton.buttonEl.addClass("hide");
+				refreshButton.buttonEl.addClass("hide");
 			});
 		}
 

--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -123,6 +123,12 @@ export class ChatContainer {
 	async handleGenerateClick(header: Header, sendButton: ButtonComponent) {
 		header.disableButtons();
 		sendButton.setDisabled(true);
+
+		// The refresh button should only be displayed on the most recent
+		// assistant message.
+		const refreshButton = this.historyMessages.querySelector('.refresh-output')
+		refreshButton?.remove()
+
 		const { model, modelName, modelType, endpointURL, modelEndpoint } =
 			getViewInfo(this.plugin, this.viewType);
 		if (this.historyMessages.children.length < 1) {

--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -247,16 +247,12 @@ export class ChatContainer {
 		}
 	}
 
-	// historyPop() {
-	// 	this.plugin.history.pop()
-	// }
 
 	historyPush(params: HistoryItem) {
 		const { modelName, historyIndex, modelEndpoint } = getViewInfo(
 			this.plugin,
 			this.viewType
 		);
-		// console.log("what we got? ", historyIndex)
 		if (historyIndex > -1) {
 			this.plugin.history.overwriteHistory(this.messages, historyIndex);
 		}

--- a/src/Plugin/Errors/errors.ts
+++ b/src/Plugin/Errors/errors.ts
@@ -14,7 +14,6 @@ export function settingsErrorHandling(params:any) {
 }
 
 export function errorMessages(error: Error, params: any) {
-    console.error('..', error)
     if(error.message === "Incorrect Settings") {
         settingsErrorHandling(params).forEach(wrongSetting => {
             new Notice(wrongSetting)

--- a/src/Plugin/Errors/errors.ts
+++ b/src/Plugin/Errors/errors.ts
@@ -14,6 +14,7 @@ export function settingsErrorHandling(params:any) {
 }
 
 export function errorMessages(error: Error, params: any) {
+    console.error('..', error)
     if(error.message === "Incorrect Settings") {
         settingsErrorHandling(params).forEach(wrongSetting => {
             new Notice(wrongSetting)

--- a/src/Types/types.ts
+++ b/src/Types/types.ts
@@ -34,6 +34,7 @@ export type TokenParams = {
 };
 
 export type Message = {
+	// TODO - abstract role 'user' into a const
 	role: "user" | "assistant";
 	content: string;
 };

--- a/styles.css
+++ b/styles.css
@@ -217,7 +217,7 @@
 	}
 }
 
-.add-text {
+.add-text, .refresh-output {
 	margin-top: auto;
 }
 
@@ -300,6 +300,7 @@ FAB MESSAGE ICON CSS
 .edit-prompt-button,
 .save-prompt-button,
 .add-text,
+.refresh-output,
 #delete-history-button {
 	padding: 4px;
 }


### PR DESCRIPTION
# What
- Add regenerate button to ChatGPT based responses

## Outstanding Work
- Do the same for image responses and ChatGPT4All responses
- This can be performed as independent follow up MRs

## Note
- My ChatGPT4All models are running locally (port is allocated), but are not picked up via this plugin.
- The LLM Modal no longer displays for me. This is where I was previously able to access the ChatGPT4All model.