### PR TITLE
Resolves ENG-118. Resolves ENG-112

### DIFF
--- a/src/Plugin/Widget/Widget.ts
+++ b/src/Plugin/Widget/Widget.ts
@@ -27,7 +27,7 @@ export class WidgetView extends ItemView {
 	}
 
 	getDisplayText(): string {
-		return "Example View";
+		return "LLM Plugin View";
 	}
 
 	async onOpen() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,13 +49,13 @@ const defaultSettings = {
 export const DEFAULT_SETTINGS: LLMPluginSettings = {
 	appName: "Local LLM Plugin",
 	modalSettings: {
-		...defaultSettings
+		...defaultSettings,
 	},
 	widgetSettings: {
-		...defaultSettings
+		...defaultSettings,
 	},
 	fabSettings: {
-		...defaultSettings
+		...defaultSettings,
 	},
 	imageAdvSettings: {
 		numberOfImages: 1,
@@ -148,7 +148,7 @@ export default class LLMPlugin extends Plugin {
 		}
 
 		// "Reveal" the leaf in case it is in a collapsed sidebar
-		// workspace.revealLeaf(leaf);
+		workspace.revealLeaf(leaf);
 	}
 
 	async loadSettings() {


### PR DESCRIPTION
Should resolve issues ENG-112, and ENG-118. 

Was not able to reproduce the modal command going away after spamming the widget command, so hopefully that was more of a one off. Widget and modal command should both now appear properly. I'm assuming this was just an issue with which code branch was included when the last release was deployed.

there should now be a command for the widget and the modal(modal command to be deprecated) and widget command should open sidebar and llm plugin view always