### PR TITLE
Add assistants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "llm-plugin",
-	"version": "0.17.1",
+	"version": "0.18.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "llm-plugin",
-			"version": "0.17.1",
+			"version": "0.18.1",
 			"license": "MIT",
 			"dependencies": {
-				"openai": "^4.28.0"
+				"openai": "^4.53.0"
 			},
 			"devDependencies": {
 				"@types/node": "^16.11.6",
@@ -885,11 +885,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/base-64": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-			"integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
-		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -952,14 +947,6 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
-		"node_modules/charenc": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-			"integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1013,14 +1000,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/crypt": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-			"integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/debug": {
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1051,15 +1030,6 @@
 			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
 			"engines": {
 				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/digest-fetch": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/digest-fetch/-/digest-fetch-1.3.0.tgz",
-			"integrity": "sha512-CGJuv6iKNM7QyZlM2T3sPAdZWd/p9zQiRNS9G+9COUCwzWFTs0Xp8NF5iePx7wtvhDykReiRRrSeNb4oMmB8lA==",
-			"dependencies": {
-				"base-64": "^0.1.0",
-				"md5": "^2.3.0"
 			}
 		},
 		"node_modules/dir-glob": {
@@ -1683,11 +1653,6 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/is-buffer": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
-		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1828,16 +1793,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/md5": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
-			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
-			"dependencies": {
-				"charenc": "0.0.2",
-				"crypt": "0.0.2",
-				"is-buffer": "~1.1.6"
-			}
-		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1975,15 +1930,14 @@
 			}
 		},
 		"node_modules/openai": {
-			"version": "4.28.0",
-			"resolved": "https://registry.npmjs.org/openai/-/openai-4.28.0.tgz",
-			"integrity": "sha512-JM8fhcpmpGN0vrUwGquYIzdcEQHtFuom6sRCbbCM6CfzZXNuRk33G7KfeRAIfnaCxSpzrP5iHtwJzIm6biUZ2Q==",
+			"version": "4.53.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-4.53.0.tgz",
+			"integrity": "sha512-XoMaJsSLuedW5eoMEMmZbdNoXgML3ujcU5KfwRnC6rnbmZkHE2Q4J/SArwhqCxQRqJwHnQUj1LpiROmKPExZJA==",
 			"dependencies": {
 				"@types/node": "^18.11.18",
 				"@types/node-fetch": "^2.6.4",
 				"abort-controller": "^3.0.0",
 				"agentkeepalive": "^4.2.1",
-				"digest-fetch": "^1.3.0",
 				"form-data-encoder": "1.7.2",
 				"formdata-node": "^4.3.2",
 				"node-fetch": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
 		"typescript": "4.7.4"
 	},
 	"dependencies": {
-		"openai": "^4.28.0"
+		"openai": "^4.53.0"
 	}
 }

--- a/src/Assistants/AssistantHandler.ts
+++ b/src/Assistants/AssistantHandler.ts
@@ -1,0 +1,24 @@
+import LLMPlugin from "main";
+import { Assistant } from "openai/resources/beta/assistants";
+import { AIAssistant } from "Types/types";
+
+export class Assistants {
+	constructor(private plugin: LLMPlugin) {}
+
+	push(assistant: AIAssistant) {
+		try {
+			let assistants = this.plugin.settings.assistants;
+			assistants.push(assistant);
+			this.plugin.settings.assistants = assistants;
+			this.plugin.saveSettings();
+			return true;
+		} catch (exception: any) {
+			return false;
+		}
+	}
+
+	reset() {
+		this.plugin.settings.assistants = [];
+		this.plugin.saveSettings();
+	}
+}

--- a/src/History/HistoryHandler.ts
+++ b/src/History/HistoryHandler.ts
@@ -1,4 +1,4 @@
-import { ChatHistoryItem, HistoryItem, Message } from "Types/types";
+import {  HistoryItem, Message } from "Types/types";
 import LLMPlugin from "main";
 
 export class History {

--- a/src/Plugin/Components/AssistantsContainer.ts
+++ b/src/Plugin/Components/AssistantsContainer.ts
@@ -109,45 +109,44 @@ export class AssistantsContainer {
 
 		submitButton.onClick(async (e: MouseEvent) => {
 			e.preventDefault();
-            //@ts-ignore
-            const basePath = app.vault.adapter.basePath
+			//@ts-ignore
+			const basePath = app.vault.adapter.basePath;
 
 			this.assistantFiles = this.files.split(",").map((file) => {
 				return `${basePath}\\${file.trim()}`;
 			});
+            
+			const assistantObj = {
+				name: this.assistantName,
+				instructions: this.assistantIntructions,
+				model: this.assistantModel,
+				tools: [{ type: this.assistantToolType }],
+			};
+			const assistant = await createAssistant(
+				assistantObj,
+				this.plugin.settings.openAIAPIKey
+			);
 
-            console.log(this.assistantFiles)
-			// const assistantObj = {
-			// 	name: this.assistantName,
-			// 	instructions: this.assistantIntructions,
-			// 	model: this.assistantModel,
-			// 	tools: [{ type: this.assistantToolType }],
-			// };
-			// const assistant = await createAssistant(
-			// 	assistantObj,
-			// 	this.plugin.settings.openAIAPIKey
-			// );
+			const vector_store_id = await createVectorAndUpdate(
+				this.assistantFiles,
+				assistant,
+				this.plugin.settings.openAIAPIKey
+			);
 
-			// const vector_store_id = await createVectorAndUpdate(
-			// 	this.assistantFiles,
-			// 	assistant,
-			// 	this.plugin.settings.openAIAPIKey
-			// );
+			this.plugin.assistants.push({
+				...assistant,
+				modelType: "assistant",
+				tool_resources: {
+					file_search: { vector_store_ids: [vector_store_id] },
+				},
+			});
 
-			// this.plugin.assistants.push({
-			// 	...assistant,
-			// 	modelType: "assistant",
-			// 	tool_resources: {
-			// 		file_search: { vector_store_ids: [vector_store_id] },
-			// 	},
-			// });
-
-            // this.resetContainer(parentContainer)
+			this.resetContainer(parentContainer);
 		});
 	}
 
-    resetContainer(parentContainer: HTMLElement) {
-        parentContainer.innerHTML = "";
-        this.generateAssistantsContainer(parentContainer)
-    }
+	resetContainer(parentContainer: HTMLElement) {
+		parentContainer.innerHTML = "";
+		this.generateAssistantsContainer(parentContainer);
+	}
 }

--- a/src/Plugin/Components/AssistantsContainer.ts
+++ b/src/Plugin/Components/AssistantsContainer.ts
@@ -1,0 +1,153 @@
+import LLMPlugin from "main";
+import {
+	ButtonComponent,
+	DropdownComponent,
+	Setting,
+	TextAreaComponent,
+} from "obsidian";
+import { ViewType } from "Types/types";
+import { models } from "utils/models";
+import {
+	createAssistant,
+	createVectorAndUpdate,
+	DEFAULT_DIRECTORY,
+} from "utils/utils";
+const fs = require("fs");
+
+export class AssistantsContainer {
+	viewType: ViewType;
+	files: string;
+	assistantName: string;
+	assistantIntructions: string;
+	assistantToolType: string;
+	assistantModel: string;
+	assistantFiles: string[];
+
+	constructor(private plugin: LLMPlugin, viewType: ViewType) {
+		this.viewType = viewType;
+	}
+
+	generateAssistantsContainer(parentContainer: HTMLElement) {
+		const assistantName = new Setting(parentContainer)
+			.setName("Assistant Name")
+			.setDesc("The name to be attributed to the new assistant")
+			.addText((text) => {
+				text.inputEl.type = "text";
+				text.onChange((change) => {
+					this.assistantName = change;
+				});
+			});
+
+		const assistantIntructions = new Setting(parentContainer)
+			.setName("Assistant Instructions")
+			.setDesc("The system instructions for the assistant to follow.")
+			.addText((text) => {
+				text.inputEl.type = "text";
+				text.onChange((change) => {
+					this.assistantIntructions = change;
+				});
+			});
+
+		const assistantToolType = new Setting(parentContainer)
+			.setName("Assistant Tool Type")
+			.setDesc("File Search or Code Review")
+			.addDropdown((dropdown: DropdownComponent) => {
+				dropdown.addOption("", "---Tool Type---");
+				dropdown.addOption("file_search", "File Search");
+				dropdown.addOption("code_interpreter", "Code Interpreter");
+
+				dropdown.onChange((change) => {
+					this.assistantToolType = change;
+					change === "file_search"
+						? files.settingEl.setAttr("style", "display:flex")
+						: files.settingEl.setAttr("style", "display:none");
+				});
+			});
+		const files = new Setting(parentContainer)
+			.setName("Files")
+			.setDesc("Files to be added for the assistant to search")
+			.addTextArea((component: TextAreaComponent) => {
+				component.onChange((change) => {
+					this.files = change;
+				});
+			});
+		files.settingEl.setAttr("style", "display:none");
+		const assistantModel = new Setting(parentContainer)
+			.setName("Assistant Model")
+			.setDesc("Which LLM you want your assistant to use")
+			.addDropdown((dropdown: DropdownComponent) => {
+				dropdown.addOption("", "---Select Model---");
+				let keys = Object.keys(models);
+				for (let model of keys) {
+					if (models[model].type === "GPT4All") {
+						fs.exists(
+							`${DEFAULT_DIRECTORY}/${models[model].model}`,
+							(exists: boolean) => {
+								if (exists) {
+									dropdown.addOption(
+										models[model].model,
+										model
+									);
+								}
+							}
+						);
+					} else {
+						dropdown.addOption(models[model].model, model);
+					}
+				}
+
+				dropdown.onChange((change) => {
+					this.assistantModel = change;
+				});
+			});
+
+		const buttonDiv = parentContainer.createDiv();
+		buttonDiv.addClass("flex", "assistants-button-div", "setting-item");
+		const submitButton = new ButtonComponent(buttonDiv);
+		submitButton.buttonEl.addClass("mod-cta", "assistants-button");
+		submitButton.buttonEl.textContent = "Create Assistant";
+
+		submitButton.onClick(async (e: MouseEvent) => {
+			e.preventDefault();
+            //@ts-ignore
+            const basePath = app.vault.adapter.basePath
+
+			this.assistantFiles = this.files.split(",").map((file) => {
+				return `${basePath}\\${file.trim()}`;
+			});
+
+            console.log(this.assistantFiles)
+			// const assistantObj = {
+			// 	name: this.assistantName,
+			// 	instructions: this.assistantIntructions,
+			// 	model: this.assistantModel,
+			// 	tools: [{ type: this.assistantToolType }],
+			// };
+			// const assistant = await createAssistant(
+			// 	assistantObj,
+			// 	this.plugin.settings.openAIAPIKey
+			// );
+
+			// const vector_store_id = await createVectorAndUpdate(
+			// 	this.assistantFiles,
+			// 	assistant,
+			// 	this.plugin.settings.openAIAPIKey
+			// );
+
+			// this.plugin.assistants.push({
+			// 	...assistant,
+			// 	modelType: "assistant",
+			// 	tool_resources: {
+			// 		file_search: { vector_store_ids: [vector_store_id] },
+			// 	},
+			// });
+
+            // this.resetContainer(parentContainer)
+		});
+	}
+
+    resetContainer(parentContainer: HTMLElement) {
+        parentContainer.innerHTML = "";
+        this.generateAssistantsContainer(parentContainer)
+    }
+}

--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -9,6 +9,8 @@ import { ChatCompletionChunk, Images } from "openai/resources";
 import { Stream } from "openai/streaming";
 import { errorMessages, settingsErrorHandling } from "Plugin/Errors/errors";
 import {
+	AssistantHistoryItem,
+	AssistantParams,
 	ChatHistoryItem,
 	ChatParams,
 	HistoryItem,
@@ -49,6 +51,15 @@ export class ChatContainer {
 
 	getParams(endpoint: string, model: string, modelType: string) {
 		const settingType = getSettingType(this.viewType);
+
+		if (modelType === "assistant") {
+			const params: AssistantParams = {
+				prompt: this.prompt,
+				messages: this.messages,
+				model,
+			};
+			return params;
+		}
 		if (endpoint === "images") {
 			const params: ImageParams = {
 				prompt: this.prompt,
@@ -112,10 +123,14 @@ export class ChatContainer {
 		// TODO - support more than chatgpt
 
 		this.previewText = "";
-		const { model, endpointURL, modelEndpoint, modelType } = getViewInfo(
-			this.plugin,
-			this.viewType
-		);
+		const {
+			model,
+			endpointURL,
+			modelEndpoint,
+			modelType,
+			assistantId,
+			modelName,
+		} = getViewInfo(this.plugin, this.viewType);
 		const params = this.getParams(modelEndpoint, model, modelType);
 		if (modelEndpoint === "assistant") {
 			const stream = await assistantsMessage(
@@ -123,26 +138,35 @@ export class ChatContainer {
 				this.messages,
 				this.plugin.settings.assistants[0].id
 			);
-			stream.on("textCreated", (text) => this.setDiv(true));
+			stream.on("textCreated", () => this.setDiv(true));
 			stream.on("textDelta", (textDelta, snapshot) => {
 				if (textDelta.value?.includes("【")) return;
 				this.previewText += textDelta.value;
 				this.streamingDiv.innerHTML = this.previewText;
 				this.historyMessages.scroll(0, 9999);
 			});
-			stream.on("end", () =>
+			stream.on("end", () => {
+				this.streamingDiv.innerHTML = "";
+				MarkdownRenderer.render(
+					this.plugin.app,
+					this.previewText,
+					this.streamingDiv,
+					"",
+					this.plugin
+				);
+				this.historyMessages.scroll(0, 9999);
 				this.messages.push({
 					role: "assistant",
 					content: this.previewText,
-				})
-			);
-			MarkdownRenderer.render(
-				this.plugin.app,
-				this.previewText,
-				this.streamingDiv,
-				"",
-				this.plugin
-			);
+				});
+				const message_context = {
+					...params,
+					messages: this.messages,
+					assistant_id: assistantId,
+					modelName,
+				} as AssistantHistoryItem;
+				this.historyPush(message_context);
+			});
 		}
 
 		if (modelEndpoint === "chat") {
@@ -283,10 +307,8 @@ export class ChatContainer {
 	}
 
 	historyPush(params: HistoryItem) {
-		const { modelName, historyIndex, modelEndpoint } = getViewInfo(
-			this.plugin,
-			this.viewType
-		);
+		const { modelName, historyIndex, modelEndpoint, assistantId } =
+			getViewInfo(this.plugin, this.viewType);
 		if (historyIndex > -1) {
 			this.plugin.history.overwriteHistory(this.messages, historyIndex);
 			return;
@@ -302,6 +324,13 @@ export class ChatContainer {
 			this.plugin.history.push({
 				...(params as ImageHistoryItem),
 				modelName,
+			});
+		}
+		if (modelEndpoint === "assistant") {
+			this.plugin.history.push({
+				...(params as AssistantHistoryItem),
+				modelName,
+				assistant_id: assistantId,
 			});
 		}
 		const length = this.plugin.settings.promptHistory.length;

--- a/src/Plugin/Components/Header.ts
+++ b/src/Plugin/Components/Header.ts
@@ -128,13 +128,13 @@ export class Header {
 		if (this.viewType === "floating-action-button") {
 			this.newChatButton = new ButtonComponent(leftButtonDiv);
 			this.settingsButton = new ButtonComponent(rightButtonsDiv);
-			const closeButton = new ButtonComponent(rightButtonsDiv);
-			closeButton.buttonEl.addClass("clickable-icon");
-			closeButton.setIcon("cross");
-			closeButton.onClick(() => {
-				const FAV = document.querySelectorAll(".fab-view-area")[0];
-				hideContainer(FAV as HTMLElement);
-			});
+		// 	const closeButton = new ButtonComponent(rightButtonsDiv);
+		// 	closeButton.buttonEl.addClass("clickable-icon");
+		// 	closeButton.setIcon("cross");
+		// 	closeButton.onClick(() => {
+		// 		const FAV = document.querySelectorAll(".fab-view-area")[0];
+		// 		hideContainer(FAV as HTMLElement);
+			// });
 		} else {
 			this.newChatButton = new ButtonComponent(rightButtonsDiv);
 			this.settingsButton = new ButtonComponent(leftButtonDiv);

--- a/src/Plugin/Components/Header.ts
+++ b/src/Plugin/Components/Header.ts
@@ -1,10 +1,11 @@
 import LLMPlugin from "main";
-import { ButtonComponent } from "obsidian";
+import { ButtonComponent, setTooltip } from "obsidian";
 import { ChatContainer } from "./ChatContainer";
 import { HistoryContainer } from "./HistoryContainer";
 import { ViewType } from "Types/types";
 import { getViewInfo, setHistoryIndex } from "utils/utils";
 import { SettingsContainer } from "./SettingsContainer";
+import { AssistantsContainer } from "./AssistantsContainer";
 
 export class Header {
 	viewType: ViewType;
@@ -16,6 +17,7 @@ export class Header {
 	chatHistoryButton: ButtonComponent;
 	newChatButton: ButtonComponent;
 	settingsButton: ButtonComponent;
+	assistantsButton: ButtonComponent;
 
 	setHeader(modelName: string, title?: string) {
 		if (title) {
@@ -45,12 +47,14 @@ export class Header {
 		this.chatHistoryButton.setDisabled(true);
 		this.newChatButton.setDisabled(true);
 		this.settingsButton.setDisabled(true);
+		this.assistantsButton.setDisabled(true);
 	}
 
 	enableButtons() {
 		this.chatHistoryButton.setDisabled(false);
 		this.newChatButton.setDisabled(false);
 		this.settingsButton.setDisabled(false);
+		this.assistantsButton.setDisabled(false);
 	}
 
 	generateHeader(
@@ -58,9 +62,11 @@ export class Header {
 		chatContainerDiv: HTMLElement,
 		chatHistoryContainerDiv: HTMLElement,
 		settingsContainerDiv: HTMLElement,
+		assistantContainerDiv: HTMLElement,
 		chatContainer: ChatContainer,
 		historyContainer: HistoryContainer,
 		settingsContainer: SettingsContainer,
+		assistantsContainer: AssistantsContainer,
 		showContainer: (container: HTMLElement) => void,
 		hideContainer: (container: HTMLElement) => void
 	) {
@@ -91,14 +97,31 @@ export class Header {
 				chatContainer,
 				this
 			);
-			this.clickHandler(this.chatHistoryButton, [this.settingsButton]);
+			this.clickHandler(this.chatHistoryButton, [this.settingsButton, this.assistantsButton]);
 			if (chatHistoryContainerDiv.style.display === "none") {
 				showContainer(chatHistoryContainerDiv);
 				hideContainer(settingsContainerDiv);
 				hideContainer(chatContainerDiv);
+				hideContainer(assistantContainerDiv);
 			} else {
 				showContainer(chatContainerDiv);
 				hideContainer(chatHistoryContainerDiv);
+			}
+		});
+
+		this.assistantsButton = new ButtonComponent(rightButtonsDiv);
+		this.assistantsButton.setTooltip("Assistants");
+		assistantsContainer.generateAssistantsContainer(assistantContainerDiv);
+		this.assistantsButton.onClick(() => {
+			this.clickHandler(this.assistantsButton, [this.settingsButton, this.chatHistoryButton]);
+			if (assistantContainerDiv.style.display === "none") {
+				showContainer(assistantContainerDiv);
+				hideContainer(settingsContainerDiv);
+				hideContainer(chatContainerDiv);
+				hideContainer(chatHistoryContainerDiv)
+			} else {
+				showContainer(chatContainerDiv);
+				hideContainer(assistantContainerDiv);
 			}
 		});
 
@@ -107,11 +130,11 @@ export class Header {
 			this.settingsButton = new ButtonComponent(rightButtonsDiv);
 			const closeButton = new ButtonComponent(rightButtonsDiv);
 			closeButton.buttonEl.addClass("clickable-icon");
-			closeButton.setIcon("cross")
+			closeButton.setIcon("cross");
 			closeButton.onClick(() => {
-				const FAV = document.querySelectorAll('.fab-view-area')[0]
-				hideContainer(FAV as HTMLElement)
-			})
+				const FAV = document.querySelectorAll(".fab-view-area")[0];
+				hideContainer(FAV as HTMLElement);
+			});
 		} else {
 			this.newChatButton = new ButtonComponent(rightButtonsDiv);
 			this.settingsButton = new ButtonComponent(leftButtonDiv);
@@ -124,11 +147,12 @@ export class Header {
 				settingsContainerDiv,
 				this
 			);
-			this.clickHandler(this.settingsButton, [this.chatHistoryButton]);
+			this.clickHandler(this.settingsButton, [this.chatHistoryButton, this.assistantsButton]);
 			if (settingsContainerDiv.style.display === "none") {
 				showContainer(settingsContainerDiv);
 				hideContainer(chatContainerDiv);
 				hideContainer(chatHistoryContainerDiv);
+				hideContainer(assistantContainerDiv);
 			} else {
 				showContainer(chatContainerDiv);
 				hideContainer(settingsContainerDiv);
@@ -141,11 +165,13 @@ export class Header {
 			this.clickHandler(this.newChatButton, [
 				this.settingsButton,
 				this.chatHistoryButton,
+				this.assistantsButton
 			]);
 			this.setHeader(modelName, "New Chat");
 			showContainer(chatContainerDiv);
 			hideContainer(settingsContainerDiv);
 			hideContainer(chatHistoryContainerDiv);
+			hideContainer(assistantContainerDiv);
 			chatContainer.resetChat();
 			chatContainer.resetMessages();
 			setHistoryIndex(this.plugin, this.viewType);
@@ -166,9 +192,11 @@ export class Header {
 			"clickable-icon",
 			"new-chat-button"
 		);
+		this.assistantsButton.buttonEl.addClass("clickable-icon", "assistants");
 		this.chatHistoryButton.setIcon("menu");
 		this.settingsButton.setIcon("sliders-horizontal");
 		this.newChatButton.setIcon("plus");
+		this.assistantsButton.setIcon("bot");
 
 		parentElement.prepend(titleDiv);
 	}

--- a/src/Plugin/Components/HistoryContainer.ts
+++ b/src/Plugin/Components/HistoryContainer.ts
@@ -44,14 +44,27 @@ export class HistoryContainer {
 			const header = this.plugin.settings.promptHistory[index].prompt;
 			const modelName =
 				this.plugin.settings.promptHistory[index].modelName;
+			const model =
+				this.plugin.settings.promptHistory[index].model;
 			this.plugin.settings[settingType].modelName = modelName;
-			this.plugin.settings[settingType].model = models[modelName].model;
-			this.plugin.settings[settingType].modelType =
-				models[modelName].type;
-			this.plugin.settings[settingType].modelEndpoint =
-				models[modelName].endpoint;
-			this.plugin.settings[settingType].endpointURL =
-				models[modelName].url;
+			if (!model.includes("asst")) {
+				this.plugin.settings[settingType].model =
+					models[modelName].model;
+				this.plugin.settings[settingType].modelType =
+					models[modelName].type;
+				this.plugin.settings[settingType].modelEndpoint =
+					models[modelName].endpoint;
+				this.plugin.settings[settingType].endpointURL =
+					models[modelName].url;
+			} else {
+				this.plugin.settings[settingType].model =
+					this.plugin.settings.promptHistory[index].model;
+				this.plugin.settings[settingType].modelName =
+					this.plugin.settings.promptHistory[index].modelName;
+				this.plugin.settings[settingType].modelType = "assistant";
+				this.plugin.settings[settingType].modelEndpoint = "assistant";
+				this.plugin.settings[settingType].endpointURL = "";
+			}
 			this.plugin.saveSettings();
 			Header.setHeader(modelName, header);
 			Header.resetHistoryButton();

--- a/src/Plugin/Components/HistoryContainer.ts
+++ b/src/Plugin/Components/HistoryContainer.ts
@@ -4,9 +4,10 @@ import { ButtonComponent, Notice } from "obsidian";
 import { ChatContainer } from "./ChatContainer";
 import { Header } from "./Header";
 import { models } from "utils/models";
+import { getSettingType } from "utils/utils";
 
 export class HistoryContainer {
-	viewType: string;
+	viewType: ViewType;
 	model: string;
 	modelName: string;
 	modelType: string;
@@ -24,37 +25,12 @@ export class HistoryContainer {
 		chat: ChatContainer,
 		Header: Header
 	) {
-		const settings: Record<string, string> = {
-			modal: "modalSettings",
-			widget: "widgetSettings",
-			"floating-action-button": "fabSettings",
-		};
-		const settingType = settings[this.viewType] as
-			| "modalSettings"
-			| "widgetSettings"
-			| "fabSettings";
-		if (this.viewType === "modal") {
-			this.model = this.plugin.settings.modalSettings.model;
-			this.modelName = this.plugin.settings.modalSettings.modelName;
-			this.modelType = this.plugin.settings.modalSettings.modelType;
-			this.modelType = this.plugin.settings.modalSettings.modelType;
-			this.historyIndex = this.plugin.settings.modalSettings.historyIndex;
-		}
-		if (this.viewType === "floating-action-button") {
-			this.model = this.plugin.settings.fabSettings.model;
-			this.modelName = this.plugin.settings.fabSettings.modelName;
-			this.modelType = this.plugin.settings.fabSettings.modelType;
-			this.modelType = this.plugin.settings.fabSettings.modelType;
-			this.historyIndex = this.plugin.settings.fabSettings.historyIndex;
-		}
-		if (this.viewType === "widget") {
-			this.model = this.plugin.settings.widgetSettings.model;
-			this.modelName = this.plugin.settings.widgetSettings.modelName;
-			this.modelType = this.plugin.settings.widgetSettings.modelType;
-			this.modelType = this.plugin.settings.widgetSettings.modelType;
-			this.historyIndex =
-				this.plugin.settings.widgetSettings.historyIndex;
-		}
+		const settingType = getSettingType(this.viewType);
+		this.model = this.plugin.settings[settingType].model;
+		this.modelName = this.plugin.settings[settingType].modelName;
+		this.modelType = this.plugin.settings[settingType].modelType;
+		this.modelType = this.plugin.settings[settingType].modelType;
+		this.historyIndex = this.plugin.settings[settingType].historyIndex;
 
 		const eventListener = () => {
 			chat.resetChat();
@@ -67,7 +43,7 @@ export class HistoryContainer {
 			const index = this.historyIndex;
 			const header = this.plugin.settings.promptHistory[index].prompt;
 			const modelName =
-			this.plugin.settings.promptHistory[index].modelName;
+				this.plugin.settings.promptHistory[index].modelName;
 			this.plugin.settings[settingType].modelName = modelName;
 			this.plugin.settings[settingType].model = models[modelName].model;
 			this.plugin.settings[settingType].modelType =

--- a/src/Plugin/Components/SettingsContainer.ts
+++ b/src/Plugin/Components/SettingsContainer.ts
@@ -1,6 +1,7 @@
-import { ViewType } from "Types/types";
-import LLMPlugin, { DEFAULT_SETTINGS, ImageSize } from "main";
+import { ImageSize, ViewType } from "Types/types";
+import LLMPlugin from "main";
 import { DropdownComponent, Setting } from "obsidian";
+import { Assistant } from "openai/resources/beta/assistants";
 import { modelNames, models } from "utils/models";
 import {
 	DEFAULT_DIRECTORY,
@@ -9,7 +10,6 @@ import {
 	getViewInfo,
 } from "utils/utils";
 import { Header } from "./Header";
-import { Assistant } from "openai/resources/beta/assistants";
 const fs = require("fs");
 
 export class SettingsContainer {
@@ -66,6 +66,10 @@ export class SettingsContainer {
 					if (change.includes("asst")) {
 						viewSettings.assistant = true;
 						this.plugin.saveSettings();
+					} else {
+						viewSettings.assistant = false;
+						viewSettings.assistantId = "";
+						this.plugin.saveSettings();
 					}
 					if (!viewSettings.assistant) {
 						const modelName = modelNames[change];
@@ -90,8 +94,8 @@ export class SettingsContainer {
 							this.plugin,
 							viewSettings.assistantId
 						);
-						viewSettings.model = assistant!.model;
-						viewSettings.modelName = modelNames[assistant!.model];
+						viewSettings.model = assistant!.id;
+						viewSettings.modelName = assistant!.name as string;
 						viewSettings.modelType = assistant!.modelType;
 						viewSettings.endpointURL = "";
 						viewSettings.modelEndpoint = "assistant";
@@ -103,6 +107,7 @@ export class SettingsContainer {
 							].modelName = modelNames[assistant!.model];
 						}
 						this.plugin.saveSettings();
+						Header.setHeader(assistant.name as string);
 					}
 					this.generateSettingsContainer(parentContainer, Header);
 				});

--- a/src/Plugin/Components/SettingsContainer.ts
+++ b/src/Plugin/Components/SettingsContainer.ts
@@ -2,8 +2,14 @@ import { ViewType } from "Types/types";
 import LLMPlugin, { DEFAULT_SETTINGS, ImageSize } from "main";
 import { DropdownComponent, Setting } from "obsidian";
 import { modelNames, models } from "utils/models";
-import { DEFAULT_DIRECTORY, getSettingType, getViewInfo } from "utils/utils";
+import {
+	DEFAULT_DIRECTORY,
+	getAssistant,
+	getSettingType,
+	getViewInfo,
+} from "utils/utils";
 import { Header } from "./Header";
+import { Assistant } from "openai/resources/beta/assistants";
 const fs = require("fs");
 
 export class SettingsContainer {
@@ -46,26 +52,58 @@ export class SettingsContainer {
 						dropdown.addOption(models[model].model, model);
 					}
 				}
+				dropdown.addOption("", "---Select Assistant---");
+				const assistants = this.plugin.settings.assistants;
+				assistants.map((assistant: Assistant) => {
+					dropdown.addOption(`${assistant.id}`, `${assistant.name}`);
+				});
 				dropdown.onChange((change) => {
 					const { historyIndex } = getViewInfo(
 						this.plugin,
 						this.viewType
 					);
-					const modelName = modelNames[change];
 					const index = historyIndex;
-					viewSettings.model = change;
-					viewSettings.modelName = modelName;
-					viewSettings.modelType = models[modelName].type;
-					viewSettings.endpointURL = models[modelName].url;
-					viewSettings.modelEndpoint = models[modelName].endpoint;
-					if (index > -1) {
-						this.plugin.settings.promptHistory[index].model =
-							change;
-						this.plugin.settings.promptHistory[index].modelName =
-							modelName;
+					if (change.includes("asst")) {
+						viewSettings.assistant = true;
+						this.plugin.saveSettings();
 					}
-					this.plugin.saveSettings();
-					Header.setHeader(modelName);
+					if (!viewSettings.assistant) {
+						const modelName = modelNames[change];
+						viewSettings.model = change;
+						viewSettings.modelName = modelName;
+						viewSettings.modelType = models[modelName].type;
+						viewSettings.endpointURL = models[modelName].url;
+						viewSettings.modelEndpoint = models[modelName].endpoint;
+						if (index > -1) {
+							this.plugin.settings.promptHistory[index].model =
+								change;
+							this.plugin.settings.promptHistory[
+								index
+							].modelName = modelName;
+						}
+						this.plugin.saveSettings();
+						Header.setHeader(modelName);
+					}
+					if (viewSettings.assistant) {
+						viewSettings.assistantId = change;
+						const assistant = getAssistant(
+							this.plugin,
+							viewSettings.assistantId
+						);
+						viewSettings.model = assistant!.model;
+						viewSettings.modelName = modelNames[assistant!.model];
+						viewSettings.modelType = assistant!.modelType;
+						viewSettings.endpointURL = "";
+						viewSettings.modelEndpoint = "assistant";
+						if (index > -1) {
+							this.plugin.settings.promptHistory[index].model =
+								assistant!.model;
+							this.plugin.settings.promptHistory[
+								index
+							].modelName = modelNames[assistant!.model];
+						}
+						this.plugin.saveSettings();
+					}
 					this.generateSettingsContainer(parentContainer, Header);
 				});
 				dropdown.setValue(viewSettings.model);

--- a/src/Plugin/FAB/FAB.ts
+++ b/src/Plugin/FAB/FAB.ts
@@ -1,3 +1,4 @@
+import { AssistantsContainer } from "Plugin/Components/AssistantsContainer";
 import { ChatContainer } from "Plugin/Components/ChatContainer";
 import { Header } from "Plugin/Components/Header";
 import { HistoryContainer } from "Plugin/Components/HistoryContainer";
@@ -45,19 +46,26 @@ export class FAB {
 			this.plugin,
 			"floating-action-button"
 		);
+		const assistantsContainer = new AssistantsContainer(
+			this.plugin,
+			"floating-action-button"
+		);
 
 		const lineBreak = viewArea.createDiv();
 		const chatContainerDiv = viewArea.createDiv();
 		const chatHistoryContainer = viewArea.createDiv();
 		const settingsContainerDiv = viewArea.createDiv();
+		const assistantsContainerDiv = viewArea.createDiv();
 		header.generateHeader(
 			viewArea,
 			chatContainerDiv,
 			chatHistoryContainer,
 			settingsContainerDiv,
+			assistantsContainerDiv,
 			chatContainer,
 			historyContainer,
 			settingsContainer,
+			assistantsContainer,
 			this.showContainer,
 			this.hideContainer
 		);
@@ -65,6 +73,8 @@ export class FAB {
 
 		settingsContainerDiv.setAttr("style", "display: none");
 		settingsContainerDiv.addClass("fab-settings-container", "flex");
+		assistantsContainerDiv.setAttr("style", "display: none");
+		assistantsContainerDiv.addClass("fab-assistants-container", "flex");
 		chatHistoryContainer.setAttr("style", "display: none");
 		chatHistoryContainer.addClass("fab-chat-history-container", "flex");
 		lineBreak.className =

--- a/src/Plugin/Modal/ChatModal2.ts
+++ b/src/Plugin/Modal/ChatModal2.ts
@@ -23,6 +23,8 @@ export class ChatModal2 extends Modal {
 		this.modalEl
 			.getElementsByClassName("modal-close-button")[0]
 			.setAttr("style", "display: none");
+		modalSettings.assistant = DEFAULT_SETTINGS.modalSettings.assistant;
+		modalSettings.assistantId = DEFAULT_SETTINGS.modalSettings.assistantId;
 		modalSettings.historyIndex =
 			DEFAULT_SETTINGS.modalSettings.historyIndex;
 		modalSettings.model = DEFAULT_SETTINGS.modalSettings.model;
@@ -44,7 +46,10 @@ export class ChatModal2 extends Modal {
 		);
 		const historyContainer = new HistoryContainer(this.plugin, "modal");
 		const settingsContainer = new SettingsContainer(this.plugin, "modal");
-		const assistantsContainer = new AssistantsContainer(this.plugin, "modal")
+		const assistantsContainer = new AssistantsContainer(
+			this.plugin,
+			"modal"
+		);
 
 		const lineBreak = contentEl.createDiv();
 		const chatContainerDiv = contentEl.createDiv();
@@ -62,7 +67,7 @@ export class ChatModal2 extends Modal {
 			settingsContainer,
 			assistantsContainer,
 			this.showContainer,
-			this.hideContainer,
+			this.hideContainer
 		);
 		let history = this.plugin.settings.promptHistory;
 

--- a/src/Plugin/Modal/ChatModal2.ts
+++ b/src/Plugin/Modal/ChatModal2.ts
@@ -5,6 +5,7 @@ import { ChatContainer } from "../Components/ChatContainer";
 import { Header } from "../Components/Header";
 import { HistoryContainer } from "../Components/HistoryContainer";
 import { SettingsContainer } from "../Components/SettingsContainer";
+import { AssistantsContainer } from "Plugin/Components/AssistantsContainer";
 
 export class ChatModal2 extends Modal {
 	constructor(private plugin: LLMPlugin) {
@@ -43,19 +44,23 @@ export class ChatModal2 extends Modal {
 		);
 		const historyContainer = new HistoryContainer(this.plugin, "modal");
 		const settingsContainer = new SettingsContainer(this.plugin, "modal");
+		const assistantsContainer = new AssistantsContainer(this.plugin, "modal")
 
 		const lineBreak = contentEl.createDiv();
 		const chatContainerDiv = contentEl.createDiv();
 		const chatHistoryContainer = contentEl.createDiv();
 		const settingsContainerDiv = contentEl.createDiv();
+		const assistantsContainerDiv = contentEl.createDiv();
 		header.generateHeader(
 			contentEl,
 			chatContainerDiv,
 			chatHistoryContainer,
 			settingsContainerDiv,
+			assistantsContainerDiv,
 			chatContainer,
 			historyContainer,
 			settingsContainer,
+			assistantsContainer,
 			this.showContainer,
 			this.hideContainer,
 		);
@@ -63,6 +68,8 @@ export class ChatModal2 extends Modal {
 
 		settingsContainerDiv.setAttr("style", "display: none");
 		settingsContainerDiv.addClass("modal-settings-container", "flex");
+		assistantsContainerDiv.setAttr("style", "display: none");
+		assistantsContainerDiv.addClass("modal-assistants-container", "flex");
 		chatHistoryContainer.setAttr("style", "display: none");
 		chatHistoryContainer.addClass("modal-chat-history-container", "flex");
 		lineBreak.className = classNames["modal"]["title-border"];

--- a/src/Plugin/Widget/Widget.ts
+++ b/src/Plugin/Widget/Widget.ts
@@ -1,3 +1,4 @@
+import { AssistantsContainer } from "Plugin/Components/AssistantsContainer";
 import { ChatContainer } from "Plugin/Components/ChatContainer";
 import { Header } from "Plugin/Components/Header";
 import { HistoryContainer } from "Plugin/Components/HistoryContainer";
@@ -60,14 +61,19 @@ export class WidgetView extends ItemView {
 		);
 		const historyContainer = new HistoryContainer(this.plugin, "widget");
 		const settingsContainer = new SettingsContainer(this.plugin, "widget");
+		const assistantsContainer = new AssistantsContainer(this.plugin, "widget")
 
 		const lineBreak = container.createDiv();
 		const chatContainerDiv = container.createDiv();
 		const chatHistoryContainer = container.createDiv();
 		const settingsContainerDiv = container.createDiv();
+		const assistantContainerDiv = container.createDiv();
 
 		settingsContainerDiv.setAttr("style", "display: none");
 		settingsContainerDiv.addClass("widget-settings-container", "flex");
+		assistantContainerDiv.setAttr("style", "display: none");
+		assistantContainerDiv.addClass("widget-assistant-container", "flex");
+		this.viewType === "tab" ? assistantContainerDiv.addClass("widget-tab-assistants") : assistantContainerDiv.addClass("widget-sidebar-assistants")
 		chatHistoryContainer.setAttr("style", "display: none");
 		chatHistoryContainer.addClass("widget-chat-history-container", "flex");
 		lineBreak.className = classNames["widget"]["title-border"];
@@ -78,9 +84,11 @@ export class WidgetView extends ItemView {
 			chatContainerDiv,
 			chatHistoryContainer,
 			settingsContainerDiv,
+			assistantContainerDiv,
 			chatContainer,
 			historyContainer,
 			settingsContainer,
+			assistantsContainer,
 			this.showContainer,
 			this.hideContainer
 		);
@@ -98,6 +106,7 @@ export class WidgetView extends ItemView {
 			settingsContainerDiv,
 			header
 		);
+		assistantsContainer.generateAssistantsContainer(settingsContainerDiv)
 	}
 
 	async onClose() {}

--- a/src/Types/types.ts
+++ b/src/Types/types.ts
@@ -1,3 +1,5 @@
+import { Assistant } from "openai/resources/beta/assistants";
+
 type InitialParams = {
 	prompt: string;
 	messages: Message[];
@@ -30,6 +32,9 @@ export type SpeechParams = {
 	responseFormat: string;
 	speed: number;
 };
+export type AIAssistant = Assistant & {
+	modelType: string
+}
 
 export type ChatHistoryItem = InitialParams &
 	ChatParams & {

--- a/src/Types/types.ts
+++ b/src/Types/types.ts
@@ -32,10 +32,16 @@ export type SpeechParams = {
 	responseFormat: string;
 	speed: number;
 };
-export type AIAssistant = Assistant & {
-	modelType: string
-}
 
+export type AIAssistant = Assistant & {
+	modelType: string;
+};
+export type AssistantParams = InitialParams;
+
+export type AssistantHistoryItem = InitialParams & {
+	assistant_id: string;
+	modelName: string;
+};
 export type ChatHistoryItem = InitialParams &
 	ChatParams & {
 		modelName: string;
@@ -54,7 +60,8 @@ export type SpeechHistoryItem = InitialParams &
 export type HistoryItem =
 	| ChatHistoryItem
 	| ImageHistoryItem
-	| SpeechHistoryItem;
+	| SpeechHistoryItem
+	| AssistantHistoryItem;
 
 export type TokenParams = {
 	prefix: string[];
@@ -77,10 +84,58 @@ export type Model = {
 export type ViewType = "modal" | "widget" | "floating-action-button";
 
 export type ViewSettings = {
+	assistant: boolean;
+	assistantId: string
 	model: string;
 	modelName: string;
 	modelType: string;
-	historyIndex: number;
 	modelEndpoint: string;
 	endpointURL: string;
+	historyIndex: number;
+	imageSettings: ImageSettings;
+	chatSettings: ChatSettings;
+	speechSettings: SpeechSettings;
 };
+
+export type ResponseFormat = "url" | "b64_json";
+export type ImageStyle = "vivid" | "natural";
+export type ImageQuality = "hd" | "standard";
+export type ImageSize =
+	| "256x256"
+	| "512x512"
+	| "1024x1024"
+	| "1024x1024"
+	| "1792x1024"
+	| "1024x1792";
+
+type SpeechSettings = {
+	voice: string;
+	responseFormat: string;
+	speed: number;
+};
+
+type ImageSettings = {
+	numberOfImages: number;
+	response_format: ResponseFormat;
+	size: ImageSize;
+	style: ImageStyle;
+	quality: ImageQuality;
+};
+
+type ChatSettings = {
+	maxTokens: number;
+	temperature: number;
+	GPT4All?: GPT4AllSettings;
+	openAI?: OpenAISettings;
+};
+
+type OpenAISettings = {
+	frequencyPenalty: number;
+	logProbs: boolean;
+	topLogProbs: number | null;
+	presencePenalty: number;
+	responseFormat: string;
+	topP: number;
+};
+
+type GPT4AllSettings = {};

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { Plugin, WorkspaceLeaf } from "obsidian";
 import { HistoryItem } from "./Types/types";
 
 import { History } from "History/HistoryHandler";
+import { Assistants } from "Assistants/AssistantHandler";
 import { ChatModal2 } from "Plugin/Modal/ChatModal2";
 import SettingsView from "Settings/SettingsView";
 import {
@@ -10,8 +11,11 @@ import {
 	WidgetView,
 } from "Plugin/Widget/Widget";
 import { FAB } from "Plugin/FAB/FAB";
+import { Assistant } from "openai/resources/beta/assistants";
 
 type ViewSettings = {
+	assistant: boolean;
+	assistantId: string
 	model: string;
 	modelName: string;
 	modelType: string;
@@ -72,12 +76,15 @@ export interface LLMPluginSettings {
 	widgetSettings: ViewSettings;
 	fabSettings: ViewSettings;
 	promptHistory: HistoryItem[];
+	assistants: Assistant[];
 	openAIAPIKey: string;
 	GPT4AllStreaming: boolean;
 	showFAB: boolean;
 }
 
 const defaultSettings = {
+	assistant: false,
+	assistantId: "",
 	model: "gpt-3.5-turbo",
 	modelName: "ChatGPT-3.5 Turbo",
 	modelType: "openAI",
@@ -108,7 +115,7 @@ const defaultSettings = {
 		voice: "alloy",
 		responseFormat: "mp3",
 		speed: 1.0,
-	},
+	}
 };
 
 export const DEFAULT_SETTINGS: LLMPluginSettings = {
@@ -123,6 +130,7 @@ export const DEFAULT_SETTINGS: LLMPluginSettings = {
 		...defaultSettings,
 	},
 	promptHistory: [],
+	assistants: [],
 	openAIAPIKey: "",
 	GPT4AllStreaming: false,
 	showFAB: true,
@@ -130,6 +138,7 @@ export const DEFAULT_SETTINGS: LLMPluginSettings = {
 
 export default class LLMPlugin extends Plugin {
 	settings: LLMPluginSettings;
+	assistants: Assistants;
 	history: History;
 	fab: FAB;
 
@@ -151,6 +160,7 @@ export default class LLMPlugin extends Plugin {
 			}, 500);
 		}
 		this.history = new History(this);
+		this.assistants = new Assistants(this)
 	}
 
 	onunload() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,74 +1,24 @@
 import { Plugin, WorkspaceLeaf } from "obsidian";
-import { HistoryItem } from "./Types/types";
-
-import { History } from "History/HistoryHandler";
-import { Assistants } from "Assistants/AssistantHandler";
-import { ChatModal2 } from "Plugin/Modal/ChatModal2";
-import SettingsView from "Settings/SettingsView";
 import {
-	TAB_VIEW_TYPE,
+	HistoryItem,
+	ImageQuality,
+	ImageSize,
+	ImageStyle,
+	ResponseFormat,
+	ViewSettings,
+} from "./Types/types";
+
+import { Assistants } from "Assistants/AssistantHandler";
+import { History } from "History/HistoryHandler";
+import { FAB } from "Plugin/FAB/FAB";
+import { ChatModal2 } from "Plugin/Modal/ChatModal2";
+import {
 	LEAF_VIEW_TYPE,
+	TAB_VIEW_TYPE,
 	WidgetView,
 } from "Plugin/Widget/Widget";
-import { FAB } from "Plugin/FAB/FAB";
+import SettingsView from "Settings/SettingsView";
 import { Assistant } from "openai/resources/beta/assistants";
-
-type ViewSettings = {
-	assistant: boolean;
-	assistantId: string
-	model: string;
-	modelName: string;
-	modelType: string;
-	modelEndpoint: string;
-	endpointURL: string;
-	historyIndex: number;
-	imageSettings: ImageSettings;
-	chatSettings: ChatSettings;
-	speechSettings: SpeechSettings;
-};
-
-export type ResponseFormat = "url" | "b64_json";
-export type ImageStyle = "vivid" | "natural";
-export type ImageQuality = "hd" | "standard";
-export type ImageSize =
-	| "256x256"
-	| "512x512"
-	| "1024x1024"
-	| "1024x1024"
-	| "1792x1024"
-	| "1024x1792";
-
-type SpeechSettings = {
-	voice: string;
-	responseFormat: string;
-	speed: number;
-};
-
-type ImageSettings = {
-	numberOfImages: number;
-	response_format: ResponseFormat;
-	size: ImageSize;
-	style: ImageStyle;
-	quality: ImageQuality;
-};
-
-type ChatSettings = {
-	maxTokens: number;
-	temperature: number;
-	GPT4All?: GPT4AllSettings;
-	openAI?: OpenAISettings;
-};
-
-type OpenAISettings = {
-	frequencyPenalty: number;
-	logProbs: boolean;
-	topLogProbs: number | null;
-	presencePenalty: number;
-	responseFormat: string;
-	topP: number;
-};
-
-type GPT4AllSettings = {};
 
 export interface LLMPluginSettings {
 	appName: string;
@@ -115,7 +65,7 @@ const defaultSettings = {
 		voice: "alloy",
 		responseFormat: "mp3",
 		speed: 1.0,
-	}
+	},
 };
 
 export const DEFAULT_SETTINGS: LLMPluginSettings = {
@@ -148,8 +98,14 @@ export default class LLMPlugin extends Plugin {
 		this.registerRibbonIcons();
 		this.registerCommands();
 
-		this.registerView(TAB_VIEW_TYPE, (tab) => new WidgetView(tab, this, "tab"));
-		this.registerView(LEAF_VIEW_TYPE, (leaf) => new WidgetView(leaf, this, "leaf"));
+		this.registerView(
+			TAB_VIEW_TYPE,
+			(tab) => new WidgetView(tab, this, "tab")
+		);
+		this.registerView(
+			LEAF_VIEW_TYPE,
+			(leaf) => new WidgetView(leaf, this, "leaf")
+		);
 
 		// This adds a settings tab so the user can configure various aspects of the plugin
 		this.fab = new FAB(this);
@@ -160,7 +116,7 @@ export default class LLMPlugin extends Plugin {
 			}, 500);
 		}
 		this.history = new History(this);
-		this.assistants = new Assistants(this)
+		this.assistants = new Assistants(this);
 	}
 
 	onunload() {
@@ -199,11 +155,13 @@ export default class LLMPlugin extends Plugin {
 			name: "Toggle LLM FAB",
 			callback: () => {
 				const currentFABState = this.settings.showFAB;
-				this.settings.showFAB = !currentFABState
+				this.settings.showFAB = !currentFABState;
 				this.saveSettings();
-				this.settings.showFAB ? this.fab.regenerateFAB() : this.fab.removeFab()
-			}
-		})
+				this.settings.showFAB
+					? this.fab.regenerateFAB()
+					: this.fab.removeFab();
+			},
+		});
 	}
 
 	private registerRibbonIcons() {

--- a/src/utils/models.ts
+++ b/src/utils/models.ts
@@ -73,6 +73,12 @@ export const models: Record<string, Model> = {
 		endpoint: "chat",
 		url: "/chat/completions",
 	},
+	"GPT-4o": {
+		model: "gpt-4o",
+		type: "openAI",
+		endpoint: "chat",
+		url: "/chat/completions",
+	},
 	// "Text to Speech": {
 	// 	model: "tts-1",
 	// 	type: "openAI",
@@ -112,6 +118,7 @@ export const modelNames: Record<string, string> = {
 	"gpt4all-13b-snoozy-q4_0.gguf": "Snoozy",
 	"em_german_mistral_v01.Q4_0.gguf": "EM German Mistral",
 	"gpt-3.5-turbo": "ChatGPT-3.5 Turbo",
+	"gpt-4o": "GPT-4o",
 	// "text-embedding-3-small": "Text Embedding 3 (Small)",
 	"dall-e-3": "DALL·E 3",
 	"dall-e-2": "DALL·E 2",

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -163,6 +163,11 @@ export function getViewInfo(
 ): ViewSettings {
 	if (viewType === "modal") {
 		return {
+			assistant: plugin.settings.modalSettings.assistant,
+			assistantId: plugin.settings.modalSettings.assistantId,
+			imageSettings: plugin.settings.modalSettings.imageSettings,
+			chatSettings: plugin.settings.modalSettings.chatSettings,
+			speechSettings: plugin.settings.modalSettings.speechSettings,
 			model: plugin.settings.modalSettings.model,
 			modelName: plugin.settings.modalSettings.modelName,
 			modelType: plugin.settings.modalSettings.modelType,
@@ -174,6 +179,11 @@ export function getViewInfo(
 
 	if (viewType === "widget") {
 		return {
+			assistant: plugin.settings.widgetSettings.assistant,
+			assistantId: plugin.settings.widgetSettings.assistantId,
+			imageSettings: plugin.settings.widgetSettings.imageSettings,
+			chatSettings: plugin.settings.widgetSettings.chatSettings,
+			speechSettings: plugin.settings.widgetSettings.speechSettings,
 			model: plugin.settings.widgetSettings.model,
 			modelName: plugin.settings.widgetSettings.modelName,
 			modelType: plugin.settings.widgetSettings.modelType,
@@ -185,6 +195,11 @@ export function getViewInfo(
 
 	if (viewType === "floating-action-button") {
 		return {
+			assistant: plugin.settings.fabSettings.assistant,
+			assistantId: plugin.settings.fabSettings.assistantId,
+			imageSettings: plugin.settings.fabSettings.imageSettings,
+			chatSettings: plugin.settings.fabSettings.chatSettings,
+			speechSettings: plugin.settings.fabSettings.speechSettings,
 			model: plugin.settings.fabSettings.model,
 			modelName: plugin.settings.fabSettings.modelName,
 			modelType: plugin.settings.fabSettings.modelType,
@@ -195,6 +210,17 @@ export function getViewInfo(
 	}
 
 	return {
+		assistant: false,
+		assistantId: "",
+		imageSettings: {
+			numberOfImages: 0,
+			response_format: "url",
+			size: "1024x1024",
+			style: "natural",
+			quality: "standard",
+		},
+		chatSettings: { maxTokens: 0, temperature: 0 },
+		speechSettings: { voice: "", responseFormat: "", speed: 0 },
 		model: "",
 		modelName: "",
 		modelType: "",
@@ -312,7 +338,7 @@ export async function createVectorAndUpdate(
 	await openai.beta.vectorStores.fileBatches.create(vectorStore.id, {
 		file_ids,
 	});
-	
+
 	await openai.beta.assistants.update(assistant.id, {
 		tool_resources: { file_search: { vector_store_ids: [vectorStore.id] } },
 	});

--- a/styles.css
+++ b/styles.css
@@ -13,6 +13,18 @@
 	display: flex;
 }
 
+.none {
+	display: none
+}
+
+.assistants-button-div {
+	justify-content: flex-end;
+}
+
+.assistants-button {
+	width: fit-content;
+}
+
 /* TITLE */
 .title {
 	flex-direction: column;
@@ -45,7 +57,7 @@
 }
 
 .right-buttons-div {
-	justify-content: space-evenly;
+	justify-content: flex-end;
 }
 
 .row-reverse {
@@ -61,7 +73,9 @@
 	flex: 4;
 }
 
-.floating-action-button-llm-title, .modal-llm-title, .widget-llm-title {
+.floating-action-button-llm-title,
+.modal-llm-title,
+.widget-llm-title {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	text-wrap: nowrap;
@@ -93,25 +107,30 @@
 
 .modal-chat-container,
 .modal-chat-history-container,
-.modal-settings-container {
+.modal-settings-container,
+.modal-assistants-container {
 	min-height: 50vh;
 }
 
 .modal-chat-container,
 .modal-chat-history-container,
-.modal-settings-container {
+.modal-settings-container,
+.modal-assistants-container {
 	max-height: var(--modal-view-max-height);
 }
 
 .modal-chat-container,
 .modal-chat-history-container,
 .modal-settings-container,
+.modal-assistants-container,
 .widget-chat-container,
 .widget-settings-container,
 .widget-chat-history-container,
+.widget-assistant-container,
 .fab-chat-container,
 .fab-settings-container,
-.fab-chat-history-container {
+.fab-chat-history-container,
+.fab-assistants-container {
 	flex-direction: column;
 	width: calc(100% - 4px);
 	padding: 0 2px 0 2px;
@@ -217,7 +236,8 @@
 	}
 }
 
-.add-text, .refresh-output {
+.add-text,
+.refresh-output {
 	margin-top: auto;
 }
 
@@ -404,6 +424,7 @@ FAB MESSAGE ICON CSS
 
 .fab-settings-container,
 .fab-chat-container,
+.fab-assistants-container,
 .fab-chat-history-container {
 	overflow-y: auto;
 	max-height: 300px;
@@ -416,17 +437,37 @@ FAB MESSAGE ICON CSS
 }
 
 .fab-settings-container,
+.fab-assistants-container,
 .widget-settings-container {
 	.setting-item {
 		flex-direction: column;
+		.setting-item-control {
+			justify-content: center;
+		}
 	}
 	.setting-item-description {
 		padding-bottom: var(--size-4-1);
 	}
 }
 
-.fab-settings-container .setting-item {
-	align-items: flex-start;
+.widget-sidebar-assistants {
+	.setting-item {
+		display: flex;
+		flex-direction: column;
+		.setting-item-control {
+			justify-content: center;
+		}
+	}
+	.assistants-button-div {
+		align-items: center;
+	}
+}
+
+.widget-tab-assistants {
+	.setting-item {
+		display: flex;
+		flex-direction: row;
+	}
 }
 
 .fab-chat-message {


### PR DESCRIPTION
This is a major update that will potentially need a fresh install if installed with BRAT.

This update fixes some minor bugs with the plugin commands now only opening one instance of any given view. If you already have an instance open, the command will focus on that instance rather than creating and opening a new instance. 

Introducing File Search with OpenAI assistants tooling.
We have added a new button to each of the plugin views headers in the form of a Robot Icon. this button will allow you to create an OpenAI assistant and upload files to attach to this assistant to allow you to interact with an LLM regarding the notes you have taken. This is still very much in beta and is purely for testing purposes so feel free to submit issues for bugs.

Some current known limitations of the assistant:
- Files are not auto updated in the vector storage so if you make changes to a note, the assistant won't have that in context unless you update the assistant
- There is currently no assistant update functionality, so updating an assistant will require remaking that assistant with the newly updated file or going to the OpenAI website to update everything manually. Update functionality will be next on my to do list
- assistant settings are currently limited to temperature and Top_P which are auto set at 1