### PR TITLE
removing an assistant option

### DIFF
--- a/src/Plugin/Components/AssistantsContainer.ts
+++ b/src/Plugin/Components/AssistantsContainer.ts
@@ -54,7 +54,7 @@ export class AssistantsContainer {
 			.addDropdown((dropdown: DropdownComponent) => {
 				dropdown.addOption("", "---Tool Type---");
 				dropdown.addOption("file_search", "File Search");
-				dropdown.addOption("code_interpreter", "Code Interpreter");
+				// dropdown.addOption("code_interpreter", "Code Interpreter");
 
 				dropdown.onChange((change) => {
 					this.assistantToolType = change;


### PR DESCRIPTION
removing an assistant option for code interpretation for now since we don't currently support it