### PR TITLE
Handle invalid ChatGPT Key

### DIFF
--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -28,6 +28,7 @@ import {
 	messageGPT4AllServer,
 	openAIMessage,
 	setHistoryIndex,
+	getApiKeyValidity
 } from "utils/utils";
 import { Header } from "./Header";
 
@@ -348,7 +349,9 @@ export class ChatContainer {
 		parentElement.scrollTo(0, 9999);
 	}
 
-	generateChatContainer(parentElement: Element, header: Header) {
+	async generateChatContainer(parentElement: Element, header: Header) {
+		await getApiKeyValidity(this.plugin.settings.openAIAPIKey)
+
 		this.messages = [];
 		this.historyMessages = parentElement.createDiv();
 		this.historyMessages.className =

--- a/src/Plugin/Components/SettingsContainer.ts
+++ b/src/Plugin/Components/SettingsContainer.ts
@@ -9,6 +9,7 @@ import {
 	getAssistant,
 	getSettingType,
 	getViewInfo,
+	getApiKeyValidity
 } from "utils/utils";
 import { Header } from "./Header";
 const fs = require("fs");
@@ -20,8 +21,9 @@ export class SettingsContainer {
 		this.viewType = viewType;
 	}
 
-	generateSettingsContainer(parentContainer: HTMLElement, Header: Header) {
-		if (this.plugin.settings.openAIAPIKey)
+	async generateSettingsContainer(parentContainer: HTMLElement, Header: Header) {
+		const hasValidApiKey = await getApiKeyValidity(this.plugin.settings.openAIAPIKey)
+		if (hasValidApiKey)
 			generateAssistantsList(this.plugin);
 		this.resetSettings(parentContainer);
 		this.generateModels(parentContainer, Header);

--- a/src/Plugin/Components/SingletonNotice.ts
+++ b/src/Plugin/Components/SingletonNotice.ts
@@ -1,0 +1,18 @@
+import { Notice } from 'obsidian';
+
+export class SingletonNotice {
+  private static activeNotice: Notice | null = null;
+
+  static show(message: string, duration: number = 4000) {
+    // If there's an active notice, do nothing.
+    if (SingletonNotice.activeNotice) return
+
+    // Otherwise show the notice
+    SingletonNotice.activeNotice = new Notice(message, duration);
+
+    // Clear the active notice reference after the duration
+    setTimeout(() => {
+      SingletonNotice.activeNotice = null;
+    }, duration);
+  }
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -12,6 +12,9 @@ import {
 	ViewSettings,
 	ViewType,
 } from "Types/types";
+import {
+	SingletonNotice
+} from "Plugin/Components/SingletonNotice"
 import { Assistant } from "openai/resources/beta/assistants";
 
 const homeDir = require("os").homedir();
@@ -43,6 +46,27 @@ export async function messageGPT4AllServer(params: ChatParams, url: string) {
 	}).then((res) => res.json());
 	return response.choices[0].message;
 }
+
+export async function getApiKeyValidity(apiKey: string) {
+	try {
+		// Make a simple API request to list models (this is lightweight)
+		const openai = new OpenAI({
+			apiKey,
+			dangerouslyAllowBrowser: true,
+		});
+		await openai.models.list();
+		return true
+	  } catch (error) {
+		if (error.status === 401) {
+		  	console.error("Invalid API key.");
+			SingletonNotice.show("Invalid API Key");
+		} else {
+		  console.log("An error occurred:", error.message);
+		}
+		return false
+	  }
+}
+
 
 /* FOR NOW USING GPT4ALL PARAMS, BUT SHOULD PROBABLY MAKE NEW OPENAI PARAMS TYPE */
 export async function openAIMessage(


### PR DESCRIPTION
# What
- Add a singleton notice 
- Display this notice when the user's plugin launches with an invalid api key.

# Why
- My OpenAI key expired in the previous months. The LLM Plugin settings still held onto that key.
- When I returned to the plugin, there was no indication of my API key being out of date.

## Potential Improvement
- The user is still able to 'try' and interact with the chat model.
- This path will never lead them anywhere.
- Disabling parts of the plugin UI that are fully dependent on a valid API key are very 'nice to have' extensions.

## Additional Implementation Critique
- Multiple calls to see if the API key are made.
- A centralized storage of the results of this validity checker is a better approach.

### Example:
- The chat container can display a CTA telling the user to:
  - use a valid API key
  - switch models

## Demo
[oo.zip](https://github.com/user-attachments/files/16663609/oo.zip)
