### PR TITLE
Update settings page to match designs

### DIFF
--- a/src/Settings/SettingsView.ts
+++ b/src/Settings/SettingsView.ts
@@ -136,8 +136,8 @@ export default class SettingsView extends PluginSettingTab {
 		credits.id = "settings-credits";
 		credits.innerHTML =
 			`<div>
-			<h2>LLM Plugin</h2>\n<p>By Johnny✨ and Ryan Mahoney </p>
-			${this.plugin.manifest.version}
+			<h2 id="hero-credits">LLM Plugin</h2>\n<p class="hero-names text-muted">By Johnny✨ and Ryan Mahoney </p>
+			<span class="text-muted version">v${this.plugin.manifest.version}</span>
 			</div>
 			`;
 	}

--- a/styles.css
+++ b/styles.css
@@ -546,8 +546,18 @@ FAB MESSAGE ICON CSS
 	text-align: center;
 }
 
-#settings-credits > h2 {
-	margin: 0;
+#hero-credits {
+	margin: 12px 0 0 0 !important;
+}
+
+.hero-names{
+	font-size: 14px;
+	margin: 0px
+}
+
+.text-muted, .version {
+	color: var(--text-muted);
+	font-size: 12px;
 }
 
 #settings-credits > p {


### PR DESCRIPTION
# What
- Styling updates to the settings page hero section
  - Rm extra margin
  - Use muted text color
  - Use correct font sizes

## Why
- Previous implementation did not match designs

## Screenshot
![image](https://github.com/user-attachments/assets/906ac0a3-5ae0-4252-8591-05ffa967d4d6)
