### PR TITLE
Cleanup various bits of broken code and minor UX enhancements

### DIFF
--- a/src/Plugin/Components/AssistantsContainer.ts
+++ b/src/Plugin/Components/AssistantsContainer.ts
@@ -461,22 +461,7 @@ export class AssistantsContainer {
 				dropdown.addOption("", "---Select Model---");
 				let keys = Object.keys(openAIModels);
 				for (let model of keys) {
-					// QUESTION -> can gtp4all have an assistant
-					if (models[model].type === GPT4All) {
-						fs.exists(
-							`${DEFAULT_DIRECTORY}/${models[model].model}`,
-							(exists: boolean) => {
-								if (exists) {
-									dropdown.addOption(
-										models[model].model,
-										model
-									);
-								}
-							}
-						);
-					} else {
-						dropdown.addOption(models[model].model, model);
-					}
+					dropdown.addOption(models[model].model, model);
 				}
 
 				dropdown.onChange((change) => {

--- a/src/Plugin/Components/AssistantsContainer.ts
+++ b/src/Plugin/Components/AssistantsContainer.ts
@@ -90,7 +90,7 @@ export class AssistantsContainer {
 	createAssistant(parentContainer: HTMLElement) {
 		const file_ids = this.createSearch(
 			parentContainer,
-			assistant,
+			ASSISTANT,
 			true
 		) as Setting;
 		this.filesSetting = file_ids;
@@ -271,7 +271,7 @@ export class AssistantsContainer {
 
 	createSearch(
 		parentContainer: HTMLElement,
-		assistantOption: assistant | "vector",
+		assistantOption: typeof ASSISTANT | "vector",
 		needsReturn?: boolean
 	) {
 		let filePathArray: string[] = [];
@@ -311,7 +311,7 @@ export class AssistantsContainer {
 							item.addClass("file-added");
 							filePathArray = [...filePathArray, option.path];
 						}
-						assistantOption === assistant
+						assistantOption === ASSISTANT
 							? (this.assistantFilesToAdd = filePathArray)
 							: (this.vectorFilesToAdd = filePathArray);
 					});

--- a/src/Plugin/Components/AssistantsContainer.ts
+++ b/src/Plugin/Components/AssistantsContainer.ts
@@ -22,7 +22,7 @@ import {
 	listAssistants,
 	listVectors,
 } from "utils/utils";
-import { assistant, GPT4All } from "utils/constants";
+import { assistant as ASSISTANT, GPT4All } from "utils/constants";
 const fs = require("fs");
 
 export class AssistantsContainer {
@@ -137,7 +137,7 @@ export class AssistantsContainer {
 
 			this.plugin.assistants.push({
 				...assistant,
-				modelType: assistant,
+				modelType: ASSISTANT,
 				tool_resources: {
 					file_search: { vector_store_ids: [vector_store_id] },
 				},

--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -297,6 +297,8 @@ export class ChatContainer {
 						this.messages.push(response);
 						this.appendNewMessage(response);
 						this.historyPush(params as ChatHistoryItem);
+						header.enableButtons();
+						sendButton.setDisabled(false);
 					}
 				);
 			} else {

--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -286,8 +286,9 @@ export class ChatContainer {
 			// 	throw new Error("Incorrect Settings");
 			// }
 			this.appendNewMessage({ role: "user", content: this.prompt });
-			if (this.plugin.settings.GPT4AllStreaming)
-				throw new Error("GPT4All streaming");
+			// This seems to be triggered much more frequently than when there streaming is in flight.
+			// if (this.plugin.settings.GPT4AllStreaming)
+			// 	throw new Error("GPT4All streaming");
 			if (modelType === GPT4All) {
 				this.plugin.settings.GPT4AllStreaming = true;
 				this.setDiv(false);
@@ -406,8 +407,14 @@ export class ChatContainer {
 	}
 
 	async generateChatContainer(parentElement: Element, header: Header) {
-		// TODO - should check the claude key versus the openAI key depending on the model
-		await getApiKeyValidity(this.plugin.settings.openAIAPIKey)
+		// Note -> we do not necessarily need a valid API key.
+		// await getApiKeyValidity(this.plugin.settings.openAIAPIKey)
+		// we just need a 'working model' (or assistant?) to generate the chat.
+
+		// If we are working with assistants, then we need a valid openAi API key.
+		// If we are working with claude, then we need a valid claude key.
+		// If we are working with a local model, then we only need to be able to perform a health check against
+		// that model.
 
 		this.messages = [];
 		this.historyMessages = parentElement.createDiv();

--- a/src/Settings/SettingsView.ts
+++ b/src/Settings/SettingsView.ts
@@ -8,7 +8,7 @@ import {
 } from "obsidian";
 import { DEFAULT_DIRECTORY } from "utils/utils";
 import { models, modelNames } from "utils/models";
-import { GPT4All } from "utils/constants";
+import { claudeSonnetJuneModel, GPT4All } from "utils/constants";
 import logo from "assets/LLMguy.svg";
 import { FAB } from "Plugin/FAB/FAB";
 const fs = require("fs");
@@ -46,7 +46,12 @@ export default class SettingsView extends PluginSettingTab {
 				text.setValue(`${this.plugin.settings.claudeAPIKey}`);
 				text.onChange((change) => {
 					this.plugin.settings.claudeAPIKey = change;
-					this.plugin.saveSettings();
+					// NOTE / Question -> We can add a prompt asking:
+					// `Do you want to set this as your default model?`
+					// This addresses the user flow where a user inputs this API key
+					// after they already have an openai key setup.
+					this.changeDefaultModel(claudeSonnetJuneModel);
+					
 				});
 			})
 			.addButton((button: ButtonComponent) => {
@@ -102,24 +107,7 @@ export default class SettingsView extends PluginSettingTab {
 					}
 				}
 				dropdown.onChange((change) => {
-					const modelName = modelNames[change];
-					DEFAULT_SETTINGS.modalSettings.model = change;
-					DEFAULT_SETTINGS.modalSettings.modelName = modelName;
-					DEFAULT_SETTINGS.modalSettings.modelType =
-						models[modelName].type;
-					DEFAULT_SETTINGS.modalSettings.endpointURL =
-						models[modelName].url;
-					DEFAULT_SETTINGS.modalSettings.modelEndpoint =
-						models[modelName].endpoint;
-					DEFAULT_SETTINGS.widgetSettings.model = change;
-					DEFAULT_SETTINGS.widgetSettings.modelName = modelName;
-					DEFAULT_SETTINGS.widgetSettings.modelType =
-						models[modelName].type;
-					DEFAULT_SETTINGS.widgetSettings.endpointURL =
-						models[modelName].url;
-					DEFAULT_SETTINGS.widgetSettings.modelEndpoint =
-						models[modelName].endpoint;
-					this.plugin.saveSettings();
+					this.changeDefaultModel(change)
 				});
 				dropdown.setValue(this.plugin.settings.modalSettings.model);
 			});
@@ -163,5 +151,31 @@ export default class SettingsView extends PluginSettingTab {
 			<span class="text-muted version">v${this.plugin.manifest.version}</span>
 			</div>
 			`;
+	}
+
+	changeDefaultModel(model: string) {
+					// Question -> why do we not update the FAB model here?
+					const modelName = modelNames[model];
+					// Modal settings
+					DEFAULT_SETTINGS.modalSettings.model = model;
+					DEFAULT_SETTINGS.modalSettings.modelName = modelName;
+					DEFAULT_SETTINGS.modalSettings.modelType =
+						models[modelName].type;
+					DEFAULT_SETTINGS.modalSettings.endpointURL =
+						models[modelName].url;
+					DEFAULT_SETTINGS.modalSettings.modelEndpoint =
+						models[modelName].endpoint;
+
+					// Widget settings
+					DEFAULT_SETTINGS.widgetSettings.model = model;
+					DEFAULT_SETTINGS.widgetSettings.modelName = modelName;
+					DEFAULT_SETTINGS.widgetSettings.modelType =
+						models[modelName].type;
+					DEFAULT_SETTINGS.widgetSettings.endpointURL =
+						models[modelName].url;1
+					DEFAULT_SETTINGS.widgetSettings.modelEndpoint =
+						models[modelName].endpoint;
+
+					this.plugin.saveSettings();
 	}
 }

--- a/src/utils/models.ts
+++ b/src/utils/models.ts
@@ -1,7 +1,23 @@
 import { Model } from "Types/types";
 import { claude, chat, GPT4All, messages } from "utils/constants"
 
+export const openAIModels: Record<string, Model> = {
+	"ChatGPT-3.5 Turbo": {
+		model: "gpt-3.5-turbo",
+		type: "openAI",
+		endpoint: chat,
+		url: "/chat/completions",
+	},
+	"GPT-4o": {
+		model: "gpt-4o",
+		type: "openAI",
+		endpoint: chat,
+		url: "/chat/completions",
+	},
+}
+
 export const models: Record<string, Model> = {
+	...openAIModels,
 	"Mistral OpenOrca": {
 		model: "mistral-7b-openorca.Q4_0.gguf",
 		type: GPT4All,
@@ -67,18 +83,6 @@ export const models: Record<string, Model> = {
 		type: GPT4All,
 		endpoint: chat,
 		url: "/v1/chat/completions",
-	},
-	"ChatGPT-3.5 Turbo": {
-		model: "gpt-3.5-turbo",
-		type: "openAI",
-		endpoint: chat,
-		url: "/chat/completions",
-	},
-	"GPT-4o": {
-		model: "gpt-4o",
-		type: "openAI",
-		endpoint: chat,
-		url: "/chat/completions",
 	},
 	// Claude Models
 	"Claude-3-5-Sonnet-20240620": {

--- a/src/utils/models.ts
+++ b/src/utils/models.ts
@@ -18,6 +18,12 @@ export const openAIModels: Record<string, Model> = {
 
 export const models: Record<string, Model> = {
 	...openAIModels,
+	"ChatGPT-3.5 Turbo GPT4All based": {
+		model: "gpt4all-gpt-3.5-turbo.rmodel",
+		type: GPT4All,
+		endpoint: chat,
+		url: "/v1/chat/completions",
+	},
 	"Mistral OpenOrca": {
 		model: "mistral-7b-openorca.Q4_0.gguf",
 		type: GPT4All,
@@ -66,8 +72,14 @@ export const models: Record<string, Model> = {
 		endpoint: chat,
 		url: "/v1/chat/completions",
 	},
-	Hermes: {
+	"Hermes 13B": {
 		model: "nous-hermes-llama2-13b.Q4_0.gguf",
+		type: GPT4All,
+		endpoint: chat,
+		url: "/v1/chat/completions",
+	},
+	"Hermes 7B": {
+		model: "Nous-Hermes-2-Mistral-7B-DPO.Q4_0.gguf",
 		type: GPT4All,
 		endpoint: chat,
 		url: "/v1/chat/completions",
@@ -126,7 +138,9 @@ export const modelNames: Record<string, string> = {
 	"orca-mini-3b-gguf2-q4_0.gguf": "Mini Orca (Small)",
 	"mpt-7b-chat-newbpe-q4_0.gguf": "MPT Chat",
 	"wizardlm-13b-v1.2.Q4_0.gguf": "Wizard v1.2",
-	"nous-hermes-llama2-13b.Q4_0.gguf": "Hermes",
+	"nous-hermes-llama2-13b.Q4_0.gguf": "Hermes 13B",
+	"Nous-Hermes-2-Mistral-7B-DPO.Q4_0.gguf": "Hermes 7B",
+	"gpt4all-gpt-3.5-turbo.rmodel": "ChatGPT-3.5 Turbo GPT4All based",
 	"gpt4all-13b-snoozy-q4_0.gguf": "Snoozy",
 	"em_german_mistral_v01.Q4_0.gguf": "EM German Mistral",
 	"gpt-3.5-turbo": "ChatGPT-3.5 Turbo",


### PR DESCRIPTION
# What
- Fix broken references against the `assistant` const
- Only display openAI hosted models for the source for assistants
- Remove API key validation from the chat container generation
- Provide user feedback about the required fields for creating an assistant
- Remove the `GPT4All` streaming defaulting to `true` -> It was coming back true even when there was no streaming.
- Add two new GPT4All models
- Fix bug where after the initial GPT4All message, the chat container buttons were all disabled
- After the addition of a Claude API key, set the default model to claude