### PR TITLE
Avoid rendering 'undefined' for assistants in history view

### DIFF
--- a/src/Plugin/Components/HistoryContainer.ts
+++ b/src/Plugin/Components/HistoryContainer.ts
@@ -147,7 +147,8 @@ export class HistoryContainer {
 		history.map((historyItem: HistoryItem, index: number) => {
 			const item = parentElement.createDiv();
 			const text = item.createEl("p");
-			text.innerHTML = historyItem.prompt;
+			const displayHTML = historyItem?.prompt || historyItem?.messages[0]?.content;
+			text.innerHTML = displayHTML;
 			const buttonsDiv = item.createDiv();
 			buttonsDiv.addClass("history-buttons-div", "flex");
 			const editPrompt = new ButtonComponent(buttonsDiv);


### PR DESCRIPTION
# What
- Existing assistant chats never displayed information about the user's prompt

## Previous State
![image](https://github.com/user-attachments/assets/17ff667d-9c60-48f5-bced-6f7cd415829f)

## Follow Up
- Navigation back into the history item for an assistant does not work. An additional PR is needed to fully support opening up historical assistant messages.