### PR TITLE
Persist default model across refresh

### DIFF
--- a/src/Plugin/Modal/ChatModal2.ts
+++ b/src/Plugin/Modal/ChatModal2.ts
@@ -1,4 +1,4 @@
-import LLMPlugin, { DEFAULT_SETTINGS } from "main";
+import LLMPlugin from "main";
 import { Modal } from "obsidian";
 import { classNames } from "utils/classNames";
 import { ChatContainer } from "../Components/ChatContainer";
@@ -19,21 +19,9 @@ export class ChatModal2 extends Modal {
 	}
 
 	onOpen() {
-		const modalSettings = this.plugin.settings.modalSettings;
 		this.modalEl
 			.getElementsByClassName("modal-close-button")[0]
 			.setAttr("style", "display: none");
-		modalSettings.assistant = DEFAULT_SETTINGS.modalSettings.assistant;
-		modalSettings.assistantId = DEFAULT_SETTINGS.modalSettings.assistantId;
-		modalSettings.historyIndex =
-			DEFAULT_SETTINGS.modalSettings.historyIndex;
-		modalSettings.model = DEFAULT_SETTINGS.modalSettings.model;
-		modalSettings.modelName = DEFAULT_SETTINGS.modalSettings.modelName;
-		modalSettings.modelType = DEFAULT_SETTINGS.modalSettings.modelType;
-		modalSettings.modelEndpoint =
-			DEFAULT_SETTINGS.modalSettings.modelEndpoint;
-		modalSettings.endpointURL = DEFAULT_SETTINGS.modalSettings.endpointURL;
-		this.plugin.saveSettings();
 		const { contentEl } = this;
 		const closeModal = () => {
 			this.close();

--- a/src/Plugin/Widget/Widget.ts
+++ b/src/Plugin/Widget/Widget.ts
@@ -40,17 +40,6 @@ export class WidgetView extends ItemView {
 
 	async onOpen() {
 		this.icon = "message-circle"
-		const widgetSettings = this.plugin.settings.widgetSettings;
-		widgetSettings.historyIndex =
-			DEFAULT_SETTINGS.widgetSettings.historyIndex;
-		widgetSettings.model = DEFAULT_SETTINGS.widgetSettings.model;
-		widgetSettings.modelName = DEFAULT_SETTINGS.widgetSettings.modelName;
-		widgetSettings.modelType = DEFAULT_SETTINGS.widgetSettings.modelType;
-		widgetSettings.modelEndpoint =
-			DEFAULT_SETTINGS.widgetSettings.modelEndpoint;
-		widgetSettings.endpointURL =
-			DEFAULT_SETTINGS.widgetSettings.endpointURL;
-		this.plugin.saveSettings();
 		const container = this.containerEl.children[1];
 		const history = this.plugin.settings.promptHistory;
 		container.empty();

--- a/src/Settings/SettingsView.ts
+++ b/src/Settings/SettingsView.ts
@@ -1,4 +1,4 @@
-import LLMPlugin, { DEFAULT_SETTINGS } from "main";
+import LLMPlugin from "main";
 import {
 	App,
 	ButtonComponent,
@@ -178,7 +178,7 @@ export default class SettingsView extends PluginSettingTab {
 			.addDropdown((dropdown: DropdownComponent) => {
 				let valueChanged = false;
 				dropdown.addOption(
-					DEFAULT_SETTINGS.modalSettings.modelName,
+					modelNames[this.plugin.settings.defaultModel],
 					"Select Default Model"
 				);
 				let keys = Object.keys(models);

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ export interface LLMPluginSettings {
 	openAIAPIKey: string;
 	GPT4AllStreaming: boolean;
 	showFAB: boolean;
+	defaultModel: string;
 }
 
 const defaultSettings = {
@@ -90,6 +91,7 @@ export const DEFAULT_SETTINGS: LLMPluginSettings = {
 	geminiAPIKey: "",
 	GPT4AllStreaming: false,
 	showFAB: true,
+	defaultModel: "",
 };
 
 export default class LLMPlugin extends Plugin {

--- a/src/main.ts
+++ b/src/main.ts
@@ -149,7 +149,7 @@ export default class LLMPlugin extends Plugin {
 
 		const openWidgetTab = this.addCommand({
 			id: "open-LLM-widget-tab",
-			name: "open Chat in Tab",
+			name: "Open Chat in Tab",
 			callback: () => {
 				this.activateTab();
 			},

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -354,26 +354,28 @@ export function changeDefaultModel(
 	model: string,
 	plugin: LLMPlugin,
 ) {
+		plugin.settings.defaultModel = model;
 		// Question -> why do we not update the FAB model here?
 		const modelName = modelNames[model];
 		// Modal settings
-		DEFAULT_SETTINGS.modalSettings.model = model;
-		DEFAULT_SETTINGS.modalSettings.modelName = modelName;
-		DEFAULT_SETTINGS.modalSettings.modelType =
+
+		plugin.settings.modalSettings.model = model;
+		plugin.settings.modalSettings.modelName = modelName;
+		plugin.settings.modalSettings.modelType =
 			models[modelName].type;
-		DEFAULT_SETTINGS.modalSettings.endpointURL =
+		plugin.settings.modalSettings.endpointURL =
 			models[modelName].url;
-		DEFAULT_SETTINGS.modalSettings.modelEndpoint =
+		plugin.settings.modalSettings.modelEndpoint =
 			models[modelName].endpoint;
 
 		// Widget settings
-		DEFAULT_SETTINGS.widgetSettings.model = model;
-		DEFAULT_SETTINGS.widgetSettings.modelName = modelName;
-		DEFAULT_SETTINGS.widgetSettings.modelType =
+		plugin.settings.widgetSettings.model = model;
+		plugin.settings.widgetSettings.modelName = modelName;
+		plugin.settings.widgetSettings.modelType =
 			models[modelName].type;
-		DEFAULT_SETTINGS.widgetSettings.endpointURL =
+		plugin.settings.widgetSettings.endpointURL =
 			models[modelName].url;
-		DEFAULT_SETTINGS.widgetSettings.modelEndpoint =
+		plugin.settings.widgetSettings.modelEndpoint =
 			models[modelName].endpoint;
 
 		plugin.saveSettings();


### PR DESCRIPTION
# What
- When a user selects a default model, then closes obsidian, upon opening a new Modal or Tab, the new default model will display

## Why
- Before after refreshing Obsidian, newly created Modals would always use Chat GPT 3.5-Turbo from DEFAULT_SETTINGS