### PR TITLE
Implement assistant icon design

### DIFF
--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -545,8 +545,14 @@ export class ChatContainer {
 	}
 
 	setDiv(streaming: boolean) {
-		this.loadingDivContainer = this.historyMessages.createDiv();
-		const loadingIcon = this.loadingDivContainer.createDiv();
+		const parent = this.historyMessages.createDiv();
+		parent.addClass("flex");
+
+		const assistant = parent.createDiv();
+		assistant.addClass("assistant-logo");
+		assistant.innerHTML = assistantLogo;
+
+		this.loadingDivContainer = parent.createDiv();
 		this.streamingDiv = this.loadingDivContainer.createDiv();
 
 		const copyToClipboardButton = new ButtonComponent(
@@ -563,8 +569,7 @@ export class ChatContainer {
 		streaming
 			? (this.streamingDiv.innerHTML = "")
 			: (this.streamingDiv.innerHTML = `<span class="bouncing-dots"><span class="dot">.</span><span class="dot">.</span><span class="dot">.</span></span>`);
-
-		loadingIcon.innerHTML = assistantLogo;
+	
 		this.streamingDiv.addClass("im-like-message");
 		this.loadingDivContainer.addClass(
 			"flex-end",

--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -555,12 +555,14 @@ export class ChatContainer {
 		this.loadingDivContainer = parent.createDiv();
 		this.streamingDiv = this.loadingDivContainer.createDiv();
 
+		const buttonsDiv = this.loadingDivContainer.createDiv()
+		buttonsDiv.addClass("assistant-buttons")
 		const copyToClipboardButton = new ButtonComponent(
-			this.loadingDivContainer
+			buttonsDiv
 		);
 		copyToClipboardButton.setIcon("files");
 
-		const refreshButton = new ButtonComponent(this.loadingDivContainer);
+		const refreshButton = new ButtonComponent(buttonsDiv);
 		refreshButton.setIcon("refresh-cw");
 
 		copyToClipboardButton.buttonEl.addClass("add-text", "hide");

--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -34,6 +34,7 @@ import {
 	setHistoryIndex
 } from "utils/utils";
 import { Header } from "./Header";
+import assistantLogo from "assets/AssistantLogo.svg";
 
 export class ChatContainer {
 	historyMessages: HTMLElement;
@@ -562,8 +563,8 @@ export class ChatContainer {
 		streaming
 			? (this.streamingDiv.innerHTML = "")
 			: (this.streamingDiv.innerHTML = `<span class="bouncing-dots"><span class="dot">.</span><span class="dot">.</span><span class="dot">.</span></span>`);
-		loadingIcon.innerHTML = "A";
-		loadingIcon.addClass("message-icon");
+
+		loadingIcon.innerHTML = assistantLogo
 		this.streamingDiv.addClass("im-like-message");
 		this.loadingDivContainer.addClass(
 			"flex-end",

--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -564,7 +564,7 @@ export class ChatContainer {
 			? (this.streamingDiv.innerHTML = "")
 			: (this.streamingDiv.innerHTML = `<span class="bouncing-dots"><span class="dot">.</span><span class="dot">.</span><span class="dot">.</span></span>`);
 
-		loadingIcon.innerHTML = assistantLogo
+		loadingIcon.innerHTML = assistantLogo;
 		this.streamingDiv.addClass("im-like-message");
 		this.loadingDivContainer.addClass(
 			"flex-end",
@@ -620,14 +620,13 @@ export class ChatContainer {
 
 	private createMessage(role: string, content: string, index: number, finalMessage: Boolean) {
 		const imLikeMessageContainer = this.historyMessages.createDiv();
-		const icon = imLikeMessageContainer.createDiv();
 		const imLikeMessage = imLikeMessageContainer.createDiv();
 		const copyToClipboardButton = new ButtonComponent(
 			imLikeMessageContainer
 		);
 
 		copyToClipboardButton.setIcon("files");
-		icon.innerHTML = role[0];
+
 		// imLikeMessage.innerHTML = content;
 		MarkdownRenderer.render(
 			this.plugin.app,
@@ -644,7 +643,7 @@ export class ChatContainer {
 		});
 		imLikeMessageContainer.addClass("im-like-message-container", "flex");
 		copyToClipboardButton.buttonEl.addClass("add-text", "hide");
-		icon.addClass("message-icon");
+
 		imLikeMessage.addClass(
 			"im-like-message",
 			classNames[this.viewType]["chat-message"]

--- a/src/assets/AssistantLogo.svg
+++ b/src/assets/AssistantLogo.svg
@@ -1,0 +1,9 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="12" cy="12" r="12" fill="url(#paint0_linear_3319_1916)"/>
+<defs>
+<linearGradient id="paint0_linear_3319_1916" x1="12" y1="-0.000414185" x2="12" y2="24" gradientUnits="userSpaceOnUse">
+<stop stop-color="var(--color-accent)"/>
+<stop offset="1" stop-color="var(--color-accent)" stop-opacity="0.1"/>
+</linearGradient>
+</defs>
+</svg>

--- a/styles.css
+++ b/styles.css
@@ -222,28 +222,49 @@
 }
 
 /* IM LIKE MESSAGE*/
+.modal-messages-div > .im-like-message-container,
+.fab-messages-div > .im-like-message-container,
+.widget-messages-div > .im-like-message-container {
+	/* We do not want to set min width on assistant messages */
+	/* only on user messages. */
+	min-width: 100%;
+}
+
 .im-like-message-container {
 	width: fit-content;
 	padding-top: 5px;
 	padding-bottom: 5px;
-	min-width: 100%;
 	margin-bottom: 10px;
 	border-radius: 5px;
-	.message-icon {
-		margin-right: auto;
-	}
 }
 
 .im-like-message-container:nth-child(2n) {
 	padding-left: 5px;
 	flex-direction: row-reverse;
-	background: var(--background-modifier-form-field);
+	border-radius: 8px;
+	border: 1px solid var(--background-modifier-border);
 	.message-icon {
 		margin-right: 5px;
 	}
 	.im-like-message {
 		text-align: left;
 	}
+}
+
+.modal-messages-div .assistant-logo + .im-like-message-container,
+.widget-messages-div .assistant-logo + .im-like-message-container {
+	background-color: var(--background-secondary);
+}
+
+.mod-sidedock .assistant-logo + .im-like-message-container,
+.fab-messages-div .assistant-logo + .im-like-message-container {
+	background-color: var(--background-primary);
+}
+
+/* TODO - vary logo margin based on view */
+.assistant-logo {
+	margin-top: var(--size-4-2);
+	margin-right: var(--size-4-2);
 }
 
 .add-text,

--- a/styles.css
+++ b/styles.css
@@ -240,7 +240,6 @@
 
 .im-like-message-container:nth-child(2n) {
 	padding-left: 5px;
-	flex-direction: row-reverse;
 	border-radius: 8px;
 	border: 1px solid var(--background-modifier-border);
 	.message-icon {
@@ -249,6 +248,20 @@
 	.im-like-message {
 		text-align: left;
 	}
+}
+
+.assistant-logo + .im-like-message-container {
+	display: flex;
+	flex-flow: column;
+}
+
+.assistant-buttons {
+	width: 85px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+	padding: 0 10px;
+	margin-bottom: 8px;
 }
 
 .modal-messages-div .assistant-logo + .im-like-message-container,
@@ -266,6 +279,7 @@
 	margin-right: var(--size-4-3);
 }
 
+.mod-sidedock .assistant-logo,
 .fab-messages-div .assistant-logo  {
 	margin-right: var(--size-4-2);
 }

--- a/styles.css
+++ b/styles.css
@@ -261,9 +261,12 @@
 	background-color: var(--background-primary);
 }
 
-/* TODO - vary logo margin based on view */
 .assistant-logo {
-	margin-top: var(--size-4-2);
+	margin-top: var(--size-4-1);
+	margin-right: var(--size-4-3);
+}
+
+.fab-messages-div .assistant-logo  {
 	margin-right: var(--size-4-2);
 }
 


### PR DESCRIPTION
# What
- Add assistant icon
- Remove the 'U' icon from in front of user messages
- Move the action buttons on assistant messages to the bottom
- Modify the background on the assistant messages to contrast with the background
- Remove the background on user messages

## Screenshots
Different color behind assistant response depending on the view (sidebar | modal | fab | tab)
![image](https://github.com/user-attachments/assets/56590d2f-f671-4a58-afb6-a2092a8c17c6)

On hover on the assistant message (note the location of the buttons)
![image](https://github.com/user-attachments/assets/56fe6c6b-f013-4c62-9e53-2760100b9286)
