### PR TITLE
fix: surface silent API errors for agent mode

### DIFF
--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -1332,7 +1332,18 @@ export class ChatContainer extends Component {
 			}
 
 			if (modelEndpoint !== images) {
+				// Agent mode bypasses handleGenerate(), so the API key guard there
+				// is never reached. Check here so the error surfaces before any SDK call.
 				if (this.supportsAgentMode(modelType)) {
+					if (modelType === claude && !this.plugin.settings.claudeAPIKey) {
+						throw new Error("No Claude API key configured. Add one in Settings → Anthropic.");
+					}
+					if (modelType === openAI && !this.plugin.settings.openAIAPIKey) {
+						throw new Error("No OpenAI API key configured. Add one in Settings → OpenAI.");
+					}
+					if (modelType === mistral && !this.plugin.settings.mistralAPIKey) {
+						throw new Error("No Mistral API key configured. Add one in Settings → Mistral.");
+					}
 					await this.runAgentMode(
 						params as ChatParams,
 						model,

--- a/src/Plugin/Errors/errors.ts
+++ b/src/Plugin/Errors/errors.ts
@@ -50,4 +50,12 @@ export function errorMessages(error: Error, params?: object) {
     if ((error as { status?: number }).status === 429 || error.message.includes("Rate limit exceeded")) {
         new Notice(error.message, 8000);
     }
+
+    if ((error as { status?: number }).status === 402 || error.message.toLowerCase().includes("credit balance") || error.message.toLowerCase().includes("insufficient credits") || error.message.toLowerCase().includes("billing")) {
+        new Notice("Your API credit balance is too low. Add credits at console.anthropic.com/settings/billing.", 10000);
+    }
+
+    if ((error as { status?: number }).status === 401 || error.message.toLowerCase().includes("authentication") || error.message.toLowerCase().includes("invalid x-api-key") || (error.message.toLowerCase().includes("api key") && error.message.toLowerCase().includes("missing"))) {
+        new Notice("Invalid or missing API key. Check your key in Settings → Model Providers.", 8000);
+    }
 }

--- a/src/Settings/LLMSettingsModal.ts
+++ b/src/Settings/LLMSettingsModal.ts
@@ -800,13 +800,16 @@ export class LLMSettingsModal extends Modal {
 				text.inputEl.type = "password";
 				text.setValue(this.plugin.settings[config.key] as string);
 				text.onChange((value) => {
-					if (value.trim().length) {
-						(this.plugin.settings[config.key] as string) = value;
-						void this.plugin.saveSettings();
-					}
+					(this.plugin.settings[config.key] as string) = value;
+					void this.plugin.saveSettings();
 					// Refresh empty state live so the setup hint appears/disappears
 					// as the user types or clears a key.
 					this.plugin.refreshAllEmptyStates();
+					// Re-render the agent settings tab so model dropdowns reflect the
+					// newly entered (or cleared) API key immediately.
+					if (this.activeTab === "obsidian-agent") {
+						this.renderTab("obsidian-agent");
+					}
 				});
 			})
 			.addButton((button: ButtonComponent) => {
@@ -1809,6 +1812,7 @@ export class LLMSettingsModal extends Modal {
 					await this.plugin.saveSettings();
 					// Regenerate FAB/StatusBar so the agent flag is picked up.
 					if (this.plugin.settings.showFAB) this.plugin.fab.regenerateFAB();
+					this.plugin.syncAllContainersAgentMode(value);
 					this.renderTab("obsidian-agent");
 				});
 			});


### PR DESCRIPTION
## Summary

- **API key guard in agent mode**: `runAgentMode` bypassed the key check that only lived in `handleGenerate()`. Empty/missing keys now throw a clear error before any SDK call.
- **HTTP 402 (no credits)**: Anthropic's insufficient-credits response was silently swallowed. Now shows: *"Your API credit balance is too low. Add credits at console.anthropic.com/settings/billing."*
- **HTTP 401 / auth errors**: Invalid key errors from the Anthropic SDK now show an actionable Notice.
- **Agent toggle sync**: Enabling the agent from the Obsidian Agent settings tab now syncs to the StatusBar container (was only regenerating the FAB).
- **API key entry UX**: Entering a key on the Anthropic tab now immediately re-renders the Agent settings tab so Claude models appear in the model dropdown without navigating away. Also fixes a bug where deleting a key wasn't persisted.

## Test plan

- [ ] Send a message with no Anthropic API key set → Notice: "No Claude API key configured..."
- [ ] Send with an invalid key → Notice: "Invalid or missing API key..."
- [ ] Send with a valid key but no credits → Notice: "Your API credit balance is too low..."
- [ ] Enable Obsidian Agent from the Agent settings tab → StatusBar popover switches to agent mode
- [ ] Enter Anthropic API key while Agent settings tab is open → Claude models appear in model dropdown immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)