### PR TITLE
Obsidian-compliance pass: dev-gated logger, lint, .llm-hidden, normalizePath

### DIFF
--- a/.claude/rules/obsidian-styling.md
+++ b/.claude/rules/obsidian-styling.md
@@ -1,0 +1,32 @@
+---
+paths:
+  - "src/Plugin/**"
+  - "src/Settings/**"
+  - "styles.css"
+---
+
+# DOM Visibility & Inline Styles (Obsidian-review compliance)
+
+Obsidian's community-plugin review flags styles assigned from JS (themes/snippets can't override them). Keep styling in `styles.css`; use JS only for genuinely dynamic values.
+
+## Show/hide — never `el.style.display`
+
+Toggle visibility with the global **`.llm-hidden`** utility (`styles.css`: `.llm-hidden { display: none !important }`) via Obsidian's `HTMLElement` helpers:
+
+- hide → `el.addClass("llm-hidden")`  ·  show → `el.removeClass("llm-hidden")`
+- conditional → `el.toggleClass("llm-hidden", shouldHide)`
+- read state → `el.hasClass("llm-hidden")` — **not** `el.style.display === "none"`
+
+The `!important` lets `.llm-hidden` override a base class's own `display`; removing it reverts to the element's CSS display, so **the element's base class must define its visible `display`** (e.g. `.llm-status-bar-popover`, `.fab-view-area`, `.llm-slash-menu`, `.llm-context-chip-container` all set `display: flex`). Never reintroduce `el.style.display = "…"` or `setAttr("style", "display: …")`.
+
+## Header-managed containers use native `.hide()` / `.show()`
+
+The chat / settings / history containers are toggled by `Header` through Obsidian's `.show()` / `.hide()` (which write inline `display`). Initialize them hidden with `.hide()`, not `setAttr("style","display:none")`. **Do not** put `.llm-hidden` on these — its `!important` would defeat `Header`'s `.show()`. FAB, StatusBarButton, Widget, and ChatModal2 follow this.
+
+## Inline `el.style.*` only for dynamic values
+
+`el.style.height` / `top` / `left` etc. are acceptable **only** for runtime-computed values with no static CSS equivalent: resize-drag heights (FAB, StatusBarButton), popover positions (`repositionPopover`), the textarea auto-height, and the caret-measurement mirror/ruler. Everything static (colour, spacing, fixed size, display) goes to a `llm-`-prefixed class in `styles.css` using Obsidian CSS vars (`--text-muted`, `--size-4-2`, …) — never hardcoded px/colours. See root `CLAUDE.md` → "Obsidian Core Styling".
+
+ESLint has **no** rule for `.style.*`, so this is convention-enforced: grep `\.style\.display` and `setAttr("style"` before adding visibility logic.
+
+Known remaining exception: the **legacy** in-settings `HistoryContainer` still uses `setAttr("style", …)` for its hover-reveal + edit/save swap (only active when `chatHistoryEnabled` is `false`). Convert it to CSS `:hover` + `.llm-hidden` if you touch that file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ Guidance for Claude Code when working in this repository — an Obsidian plugin 
 ```bash
 npm run dev      # watch mode (esbuild)
 npm run build    # production build (tsc type-check + esbuild bundle)
+npm run lint     # eslint src  (lint:fix to autofix) — prefer-const/eqeqeq/no-console are warnings
 npm run version  # bump manifest.json and versions.json
 npm run test:e2e # E2E suite — real sandboxed Obsidian via wdio-obsidian-service (see test/README.md)
 ```
@@ -96,6 +97,7 @@ Each feature has a path-scoped rules file under `.claude/rules/` that loads auto
 | Chats Panel — `ChatsView` + `ChatsSidebar`, row menu | `src/Plugin/ChatsView/` | `chats-panel.md` |
 | Chat Details Panel — live context sidebar | `src/Plugin/ChatDetailsView/` | `chat-details.md` |
 | Feature gates — `featureSettings` toggles in settings modal | `src/Settings/` | `feature-gates.md` |
+| DOM visibility & inline styles — `.llm-hidden`, native hide/show, dynamic-only `style.*` | `src/Plugin/`, `src/Settings/`, `styles.css` | `obsidian-styling.md` |
 
 Shared conventions across features: Skills/Projects/Assistants/Memories folders all derive from `rootVaultFolder` (default `"AI"`); managers (`SkillRegistry`, `ProjectManager`, `AssistantManager`) follow the same discovery/parsing/hot-reload pattern and have `reinit*()` methods called on `rootVaultFolder` change; all settings sub-objects are deep-merged in `loadSettings()`.
 
@@ -117,6 +119,15 @@ Always use `getSettingType("floating-action-button") as "fabSettings"` for a typ
 
 `ChatContainer.slashMenuEl` (floating menu on `document.body`, `position: fixed`) is an instance variable so each container removes only its own menu. Do NOT `document.querySelectorAll(".llm-slash-menu").forEach(el => el.remove())` — that destroys other views' menus. Cleaned up in `destroy()`.
 
+## Obsidian Compliance Conventions
+
+Keep the plugin aligned with Obsidian's community-plugin review. `npm run lint` guards what it can; the rest is convention.
+
+- **Logging** — never call `console.*` directly. Use the singleton `logger` from `src/utils/logger.ts`: `logger.debug/log/info` are stripped from production builds (gated on the esbuild-injected `__DEV__`), `logger.warn/error` always emit with an `[LLM]` prefix. ESLint's `no-console: warn` flags raw console; `logger.ts` is the only exemption.
+- **DOM visibility & inline styles** — toggle visibility with the `.llm-hidden` class, never `el.style.display`; reserve inline `el.style.*` for genuinely dynamic values. Full rules in `.claude/rules/obsidian-styling.md` (auto-loads for `src/Plugin/**`, `src/Settings/**`, `styles.css`).
+- **Vault paths** — wrap user-supplied / derived vault paths in `normalizePath()` (the `rootVaultFolder` folder getters in `main.ts` do this).
+- **`as any`** — acceptable for undocumented Obsidian internals (`app.plugins`, `vault.adapter`, `workspace`, `globalThis`) and `Menu.setSubmenu()`, which lack public types; don't add it for typeable code (prefer `instanceof TFile` over `(file as any).extension`).
+
 ## Obsidian Core Styling — Use Native Before Custom
 
 Always prefer Obsidian's built-in components and CSS classes; native gets theming, accessibility, and hover/focus states for free.
@@ -135,7 +146,7 @@ Always prefer Obsidian's built-in components and CSS classes; native gets themin
 
 When custom CSS is unavoidable:
 - Always use Obsidian CSS variables (`--text-muted`, `--interactive-accent`, `--font-ui-small`, `--icon-s`, `--size-4-2`, …) — never hardcoded colours/px/font sizes. Use `--icon-xs`/`--icon-s` for icons.
-- Custom classes go in `styles.css` with the `llm-` prefix. Never inline `element.style.*` in TypeScript — use `.addClass()` with a named class.
+- Custom classes go in `styles.css` with the `llm-` prefix. Never inline `element.style.*` in TypeScript — use `.addClass()` with a named class; toggle visibility via the `.llm-hidden` utility (not `style.display`). Inline `el.style.*` is for genuinely dynamic values only (computed sizes/positions). See `.claude/rules/obsidian-styling.md`.
 - Writing hover/focus/active states for a list row? Stop — use `tree-item-self`, which already has them.
 
 ## Key Files

--- a/esbuild.config.mjs
+++ b/esbuild.config.mjs
@@ -48,7 +48,7 @@ const context = await esbuild.context({
 		...builtinModules.map(m => `node:${m}`),
 	],
 	format: "cjs",
-	define: { "import.meta.url": "__import_meta_url" },
+	define: { "import.meta.url": "__import_meta_url", "__DEV__": (!prod).toString() },
 	loader: { ".svg": "text" },
 	target: "es2018",
 	logLevel: "info",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -23,8 +23,18 @@ export default tseslint.config(
 			"@typescript-eslint/no-require-imports": "off",
 			"@typescript-eslint/no-unused-expressions": "off",
 			"@typescript-eslint/no-wrapper-object-types": "off",
-			"prefer-const": "off",
+			// Re-enabled as warnings (not errors, so `npm run lint` stays green) to
+			// guide gradual cleanup — these mirror the Obsidian best-practice rules
+			// enforced by the sister plugins.
+			"prefer-const": "warn",
+			"eqeqeq": ["warn", "smart"],
+			"no-console": "warn",
 		},
+	},
+	{
+		// The logger module is the one sanctioned place to call console.*.
+		files: ["src/utils/logger.ts"],
+		rules: { "no-console": "off" },
 	},
 	{
 		// Type-aware linting, scoped to the one type-checked rule we care about

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
 		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+		"lint": "eslint src",
+		"lint:fix": "eslint src --fix",
 		"version": "node version-bump.mjs && git add manifest.json versions.json",
 		"test:e2e": "npm run build && tsc -noEmit -p test && node scripts/stage-plugin.mjs && wdio run ./wdio.conf.mts"
 	},

--- a/src/Assistants/AssistantManager.ts
+++ b/src/Assistants/AssistantManager.ts
@@ -28,6 +28,7 @@
  */
 
 import { App, TFile } from "obsidian";
+import { logger } from "../utils/logger";
 import { Assistant } from "Types/types";
 
 export class AssistantManager {
@@ -116,10 +117,10 @@ export class AssistantManager {
 			const assistant = AssistantManager.parseAssistantFile(raw, filePath, this.assistantsFolder);
 			if (assistant) {
 				this.assistants.set(assistant.id, assistant);
-				console.log(`[AssistantManager] Loaded assistant: ${assistant.id} (${assistant.name})`);
+				logger.log(`[AssistantManager] Loaded assistant: ${assistant.id} (${assistant.name})`);
 			}
 		} catch (e) {
-			console.error(`[AssistantManager] Failed to parse ${filePath}:`, e);
+			logger.error(`[AssistantManager] Failed to parse ${filePath}:`, e);
 		}
 	}
 
@@ -202,7 +203,7 @@ ${systemPrompt || "<!-- Add your assistant's system prompt / persona instruction
 			await this.loadAssistantByPath(filePath);
 			return filePath;
 		} catch (e) {
-			console.error(`[AssistantManager] Failed to create assistant at ${filePath}:`, e);
+			logger.error(`[AssistantManager] Failed to create assistant at ${filePath}:`, e);
 			return null;
 		}
 	}
@@ -222,7 +223,7 @@ ${systemPrompt || "<!-- Add your assistant's system prompt / persona instruction
 			}
 			this.assistants.delete(id);
 		} catch (e) {
-			console.error(`[AssistantManager] Failed to delete assistant ${id}:`, e);
+			logger.error(`[AssistantManager] Failed to delete assistant ${id}:`, e);
 		}
 	}
 

--- a/src/Memory/MemoryService.ts
+++ b/src/Memory/MemoryService.ts
@@ -29,6 +29,7 @@
  */
 
 import { App, Notice } from "obsidian";
+import { logger } from "../utils/logger";
 import { VaultIndexer } from "RAG/VaultIndexer";
 import { EmbeddingService } from "RAG/EmbeddingService";
 import { Message } from "Types/types";
@@ -146,7 +147,7 @@ export class MemoryService {
 		// Still check for duplicates so repeated /remember calls don't pile up
 		const isDuplicate = await this.isDuplicate(content, folder);
 		if (isDuplicate) {
-			console.log(`[Memory] /remember duplicate skipped: "${content.slice(0, 60)}"`);
+			logger.log(`[Memory] /remember duplicate skipped: "${content.slice(0, 60)}"`);
 			return null;
 		}
 
@@ -156,7 +157,7 @@ export class MemoryService {
 		const fileContent = `---\ncreated: ${created}\nsource: ${source}\ntype: ${type}\n---\n\n${content}\n`;
 		const filePath = `${folder}/${id}.md`;
 		await this.app.vault.adapter.write(filePath, fileContent);
-		console.log(`[Memory] Direct save: ${filePath}`);
+		logger.log(`[Memory] Direct save: ${filePath}`);
 		return filePath;
 	}
 
@@ -191,7 +192,7 @@ export class MemoryService {
 		for (const mem of extracted) {
 			const isDuplicate = await this.isDuplicate(mem.content, folder);
 			if (isDuplicate) {
-				console.log(`[Memory] Skipping duplicate: "${mem.content.slice(0, 60)}…"`);
+				logger.log(`[Memory] Skipping duplicate: "${mem.content.slice(0, 60)}…"`);
 				continue;
 			}
 			await this.writeMemory(folder, scope, scopeName, mem);
@@ -242,7 +243,7 @@ Keep each content item to one clear, standalone sentence.`;
 		try {
 			raw = await callModel(system, user);
 		} catch (e) {
-			console.error("[Memory] Extraction model call failed:", e);
+			logger.error("[Memory] Extraction model call failed:", e);
 			new Notice("Memory extraction failed — model call error.");
 			return [];
 		}
@@ -263,7 +264,7 @@ Keep each content item to one clear, standalone sentence.`;
 					["fact", "preference", "context"].includes(item.type)
 			);
 		} catch (e) {
-			console.error("[Memory] Failed to parse extraction JSON:", cleaned, e);
+			logger.error("[Memory] Failed to parse extraction JSON:", cleaned, e);
 			return [];
 		}
 	}
@@ -283,7 +284,7 @@ Keep each content item to one clear, standalone sentence.`;
 			newVector = await this.embedding.embed(content);
 		} catch (e) {
 			// If embedding fails we can't check — allow the write
-			console.warn("[Memory] Embedding failed during dedup check:", e);
+			logger.warn("[Memory] Embedding failed during dedup check:", e);
 			return false;
 		}
 
@@ -326,7 +327,7 @@ ${mem.content}
 
 		const filePath = `${folder}/${id}.md`;
 		await this.app.vault.adapter.write(filePath, fileContent);
-		console.log(`[Memory] Wrote memory: ${filePath}`);
+		logger.log(`[Memory] Wrote memory: ${filePath}`);
 	}
 
 	// ── Recall ───────────────────────────────────────────────────────────────────
@@ -369,7 +370,7 @@ ${mem.content}
 			queryVec = await this.embedding.embed(query);
 		} catch (e) {
 			// Embedding failed — fall back to returning all memories up to topK
-			console.warn("[Memory] Query embedding failed during recall, using all memories:", e);
+			logger.warn("[Memory] Query embedding failed during recall, using all memories:", e);
 			const fallback = allMemories.slice(0, topK);
 			return {
 				context: formatMemoriesAsContext(fallback.map(m => m.content)),
@@ -394,7 +395,7 @@ ${mem.content}
 		scored.sort((a, b) => b.score - a.score);
 		const top = scored.slice(0, topK);
 
-		console.log(`[Memory] Recalled ${top.length} memories (best score: ${top[0]?.score.toFixed(3)})`);
+		logger.log(`[Memory] Recalled ${top.length} memories (best score: ${top[0]?.score.toFixed(3)})`);
 		return {
 			context: formatMemoriesAsContext(top.map(s => s.content)),
 			memories: top.map(s => ({ content: s.content, filePath: s.filePath })),
@@ -423,7 +424,7 @@ ${mem.content}
 				const parsed = parseMemoryFile(raw, filePath);
 				if (parsed) records.push(parsed);
 			} catch (e) {
-				console.warn(`[Memory] Failed to read ${filePath}:`, e);
+				logger.warn(`[Memory] Failed to read ${filePath}:`, e);
 			}
 		}
 		return records;

--- a/src/Plugin/ChatsView/ChatsView.ts
+++ b/src/Plugin/ChatsView/ChatsView.ts
@@ -7,6 +7,7 @@ import {
 	WorkspaceLeaf,
 	setIcon,
 } from "obsidian";
+import { logger } from "../../utils/logger";
 import LLMPlugin from "main";
 import { CHATS_VIEW_TYPE } from "utils/constants";
 import { attachChatRowMenu } from "Plugin/Components/ChatRowMenuHelper";
@@ -115,7 +116,7 @@ export class ChatsView extends ItemView {
 		try {
 			this.allFiles = await this.plugin.chatHistory.list();
 		} catch (e) {
-			console.error("[ChatsView] Failed to list chat files:", e);
+			logger.error("[ChatsView] Failed to list chat files:", e);
 			this.allFiles = [];
 		}
 		this.applyFilter();

--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -1,4 +1,5 @@
 import LLMPlugin from "main";
+import { logger } from "../../utils/logger";
 import {
 	ButtonComponent,
 	Component,
@@ -502,7 +503,7 @@ export class ChatContainer extends Component {
 		}
 		const params = this.getParams(modelEndpoint, model, modelType);
 		if (params && "tokens" in params) {
-			(params as import("Types/types").ChatParams).tokens = this.resolveEffectiveMaxTokens(0) || undefined;
+			params.tokens = this.resolveEffectiveMaxTokens(0) || undefined;
 		}
 		// Start Claude Code handling
 		if (modelEndpoint === claudeCodeEndpoint) {
@@ -643,7 +644,7 @@ export class ChatContainer extends Component {
 					};
 				}
 			} catch (err) {
-				console.error(err);
+				logger.error(err);
 				return false;
 			}
 
@@ -968,7 +969,7 @@ export class ChatContainer extends Component {
 					this.pendingContextString = contextString;
 				}
 			} catch (error) {
-				console.error("Error building vault context:", error);
+				logger.error("Error building vault context:", error);
 			}
 		}
 
@@ -995,7 +996,7 @@ export class ChatContainer extends Component {
 						(this.pendingContextString ? "\n\n---\n\n" + this.pendingContextString : "");
 				}
 			} catch (error) {
-				console.error("[RAG] Vault search failed:", error);
+				logger.error("[RAG] Vault search failed:", error);
 				new Notice("Vault search failed — sending without vault context.");
 			}
 		}
@@ -1022,7 +1023,7 @@ export class ChatContainer extends Component {
 					};
 				}
 			} catch (error) {
-				console.error("Error reading active file for context:", error);
+				logger.error("Error reading active file for context:", error);
 			}
 		}
 
@@ -1186,7 +1187,7 @@ export class ChatContainer extends Component {
 				);
 				this.messageStore.addMessage({ role: assistant, content: response });
 			} catch (e) {
-				console.error("[Memory] /remember save failed:", e);
+				logger.error("[Memory] /remember save failed:", e);
 				new Notice("Failed to save memory — see console for details.");
 			}
 
@@ -1310,7 +1311,7 @@ export class ChatContainer extends Component {
 							(this.pendingContextString ? "\n\n---\n\n" + this.pendingContextString : "");
 					}
 				} catch (e) {
-					console.error("[Projects] Failed to build pinned notes context:", e);
+					logger.error("[Projects] Failed to build pinned notes context:", e);
 				}
 			}
 
@@ -1340,7 +1341,7 @@ export class ChatContainer extends Component {
 					}
 				}
 			} catch (e) {
-				console.warn("[ChatContainer] Could not read AGENTS.md:", e);
+				logger.warn("[ChatContainer] Could not read AGENTS.md:", e);
 			}
 		}
 		// ── End general instructions ──────────────────────────────────────────────
@@ -1376,7 +1377,7 @@ export class ChatContainer extends Component {
 					this.pushChatDetailsState();
 				}
 			} catch (e) {
-				console.error("[Memory] Recall failed:", e);
+				logger.error("[Memory] Recall failed:", e);
 			}
 		}
 		// ── End memory recall ─────────────────────────────────────────────────────
@@ -1410,7 +1411,7 @@ export class ChatContainer extends Component {
 		await this.renderingPromise;
 		const params = this.getParams(modelEndpoint, model, modelType);
 		if (params && "tokens" in params) {
-			(params as import("Types/types").ChatParams).tokens = effectiveMaxTokens || undefined;
+			params.tokens = effectiveMaxTokens || undefined;
 		}
 		// Snapshot the assistant-message count before generation so we can key
 		// skill usage (and tool calls on the non-agent path) to the right turn.
@@ -2127,7 +2128,7 @@ export class ChatContainer extends Component {
 				vaultContext,
 				historyFilePath
 			).catch((e) =>
-				console.error("[ChatContainer] Failed to save chat file:", e)
+				logger.error("[ChatContainer] Failed to save chat file:", e)
 			);
 			return;
 		}
@@ -2250,7 +2251,7 @@ export class ChatContainer extends Component {
 		if (projectId) {
 			const project = this.plugin.projectManager?.getProject(projectId);
 			if (!project) {
-				console.warn(`[ChatContainer] setActiveProject: project not found: ${projectId}`);
+				logger.warn(`[ChatContainer] setActiveProject: project not found: ${projectId}`);
 				return;
 			}
 			targetFolder = this.plugin.chatHistory.folderForProject(projectId);
@@ -2279,7 +2280,7 @@ export class ChatContainer extends Component {
 						this.currentHistoryFilePath = newPath;
 						setHistoryFilePath(this.plugin, this.viewType, newPath);
 					} catch (e) {
-						console.error("[ChatContainer] Failed to move chat file:", e);
+						logger.error("[ChatContainer] Failed to move chat file:", e);
 					}
 				} else {
 					// File is already in the right folder — just patch the frontmatter field
@@ -2849,13 +2850,13 @@ export class ChatContainer extends Component {
 			try {
 				const { displayName, file } = this.resolvePinnedNote(notePath);
 				if (!file) {
-					console.warn(`[Projects] Pinned note not found: ${notePath}`);
+					logger.warn(`[Projects] Pinned note not found: ${notePath}`);
 					continue;
 				}
 				const content = await this.plugin.app.vault.read(file);
 				blocks.push(`### ${displayName}\nPath: \`${file.path}\`\n\n${content}`);
 			} catch (e) {
-				console.warn(`[Projects] Failed to read pinned note ${notePath}:`, e);
+				logger.warn(`[Projects] Failed to read pinned note ${notePath}:`, e);
 			}
 		}
 
@@ -3562,7 +3563,7 @@ export class ChatContainer extends Component {
 						`Mic error: ${err instanceof Error ? err.message : String(err)}`,
 						7000,
 					);
-					console.error("[LLM Plugin] Mic button error:", err);
+					logger.error("[LLM Plugin] Mic button error:", err);
 				}
 			});
 		}
@@ -4449,7 +4450,7 @@ export class ChatContainer extends Component {
 					? "No microphone found. Please connect one and try again."
 					: `Microphone error: ${err?.name} — ${err?.message ?? err}`;
 			new Notice(msg, 7000);
-			console.error("[LLM Plugin] getUserMedia failed:", err);
+			logger.error("[LLM Plugin] getUserMedia failed:", err);
 			return;
 		}
 
@@ -4804,7 +4805,7 @@ export class ChatContainer extends Component {
 				callModel,
 			);
 		} catch (e) {
-			console.error("[Memory] Extraction failed:", e);
+			logger.error("[Memory] Extraction failed:", e);
 			new Notice("Memory extraction failed — see console for details.");
 		}
 	}
@@ -4821,7 +4822,7 @@ export class ChatContainer extends Component {
 		) {
 			// Fire-and-forget — don't block the UI
 			this.extractMemories().catch((e) =>
-				console.error("[Memory] End-of-chat extraction failed:", e)
+				logger.error("[Memory] End-of-chat extraction failed:", e)
 			);
 		}
 

--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -292,9 +292,9 @@ export class ChatContainer extends Component {
 		sendButton.buttonEl.addClass("llm-stop-mode");
 		sendButton.setDisabled(false);
 		// Always show the stop button regardless of input contents
-		sendButton.buttonEl.style.display = "";
+		sendButton.buttonEl.removeClass("llm-hidden");
 		if (this.micButton) {
-			this.micButton.buttonEl.style.display = "none";
+			this.micButton.buttonEl.addClass("llm-hidden");
 		}
 	}
 
@@ -310,8 +310,8 @@ export class ChatContainer extends Component {
 		sendButton.setDisabled(isEmpty);
 		sendButton.buttonEl.toggleClass("llm-send-button-disabled", isEmpty);
 		if (this.micButton && this.micState === "idle") {
-			this.micButton.buttonEl.style.display = isEmpty ? "" : "none";
-			sendButton.buttonEl.style.display = isEmpty ? "none" : "";
+			this.micButton.buttonEl.toggleClass("llm-hidden", !isEmpty);
+			sendButton.buttonEl.toggleClass("llm-hidden", isEmpty);
 		}
 	}
 
@@ -2693,11 +2693,11 @@ export class ChatContainer extends Component {
 		const hasLocalPaths = this.localContextPaths.length > 0;
 
 		if (!hasActiveFile && !hasAdditional && !hasPinned && !hasProject && !hasLocalPaths) {
-			this.chipContainer.style.display = "none";
+			this.chipContainer.addClass("llm-hidden");
 			return;
 		}
 
-		this.chipContainer.style.display = "flex";
+		this.chipContainer.removeClass("llm-hidden");
 
 		// Project chip — icon-only at rest, name revealed on hover
 		if (hasProject && activeProject) {
@@ -2884,7 +2884,7 @@ export class ChatContainer extends Component {
 		// Chip strip — shown for all view types; scan button only for FAB/Modal
 		this.chipContainer = promptContainer.createDiv();
 		this.chipContainer.addClass("llm-context-chip-container");
-		this.chipContainer.style.display = "none";
+		this.chipContainer.addClass("llm-hidden");
 
 		// Input area (textarea only — skill prefix is inserted as inline text)
 		const inputSection = promptContainer.createDiv();
@@ -2898,7 +2898,7 @@ export class ChatContainer extends Component {
 		// keeps it invisible to mouse/keyboard so the real textarea handles all input.
 		const mirrorDiv = promptWrapper.createDiv();
 		mirrorDiv.addClass("llm-input-mirror");
-		mirrorDiv.style.display = "none";
+		mirrorDiv.addClass("llm-hidden");
 
 		const promptField = new TextAreaComponent(promptWrapper);
 		promptField.inputEl.className = classNames[this.viewType]["text-area"];
@@ -2915,7 +2915,7 @@ export class ChatContainer extends Component {
 		this.slashMenuEl?.remove();
 		this.slashMenuEl = document.body.createDiv({ cls: "llm-slash-menu" });
 		const slashMenu = this.slashMenuEl;
-		slashMenu.style.display = "none";
+		slashMenu.addClass("llm-hidden");
 		let slashMenuIndex = 0;
 		let slashMenuSkills: ParsedSkill[] = [];
 
@@ -2941,7 +2941,7 @@ export class ChatContainer extends Component {
 		};
 
 		const repositionHandler = () => {
-			if (slashMenu.style.display !== "none") positionSlashMenu();
+			if (!slashMenu.hasClass("llm-hidden")) positionSlashMenu();
 		};
 		window.addEventListener("resize", repositionHandler);
 
@@ -2968,7 +2968,7 @@ export class ChatContainer extends Component {
 			// Index mapping: 0 = local path item (if shown), then skills
 			slashMenuIndex = 0;
 			const totalItems = (showLocalPath ? 1 : 0) + skills.length;
-			if (totalItems === 0) { slashMenu.style.display = "none"; return; }
+			if (totalItems === 0) { slashMenu.addClass("llm-hidden"); return; }
 
 			if (showLocalPath) {
 				if (skills.length > 0) {
@@ -3039,7 +3039,7 @@ export class ChatContainer extends Component {
 				item.dataset.menuIndex = String(globalIdx);
 			}
 
-			slashMenu.style.display = "flex";
+			slashMenu.removeClass("llm-hidden");
 			positionSlashMenu();
 		};
 
@@ -3088,7 +3088,7 @@ export class ChatContainer extends Component {
 		};
 
 		const hideSlashMenu = () => {
-			slashMenu.style.display = "none";
+			slashMenu.addClass("llm-hidden");
 			slashMenuSkills = [];
 			slashMenuIndex = 0;
 		};
@@ -3151,19 +3151,19 @@ export class ChatContainer extends Component {
 				restSpan.textContent = rest;
 				// Trailing sentinel keeps last-line height correct when rest ends in \n
 				mirrorDiv.createSpan().textContent = "​";
-				mirrorDiv.style.display = "";
+				mirrorDiv.removeClass("llm-hidden");
 				promptField.inputEl.addClass("llm-input-with-mirror");
 				// Keep mirror scroll in sync
 				mirrorDiv.scrollTop = promptField.inputEl.scrollTop;
 			} else {
-				mirrorDiv.style.display = "none";
+				mirrorDiv.addClass("llm-hidden");
 				promptField.inputEl.removeClass("llm-input-with-mirror");
 			}
 		};
 
 		// Sync mirror scroll whenever the textarea scrolls
 		promptField.inputEl.addEventListener("scroll", () => {
-			if (mirrorDiv.style.display !== "none") {
+			if (!mirrorDiv.hasClass("llm-hidden")) {
 				mirrorDiv.scrollTop = promptField.inputEl.scrollTop;
 			}
 		});
@@ -3588,8 +3588,8 @@ export class ChatContainer extends Component {
 			sendButton.buttonEl.toggleClass("llm-send-button-disabled", isEmpty);
 			// When Whisper is enabled and mic is idle, swap visibility with send button
 			if (this.micButton && this.micState === "idle") {
-				this.micButton.buttonEl.style.display = isEmpty ? "" : "none";
-				sendButton.buttonEl.style.display     = isEmpty ? "none" : "";
+				this.micButton.buttonEl.toggleClass("llm-hidden", !isEmpty);
+				sendButton.buttonEl.toggleClass("llm-hidden", isEmpty);
 			}
 		};
 
@@ -3637,7 +3637,7 @@ export class ChatContainer extends Component {
 
 		promptField.inputEl.addEventListener("keydown", (event) => {
 			// Handle slash menu keyboard navigation first
-			if (slashMenu.style.display !== "none") {
+			if (!slashMenu.hasClass("llm-hidden")) {
 				if (event.key === "ArrowDown") {
 					event.preventDefault();
 					slashMenuIndex = Math.min(slashMenuIndex + 1, slashMenuTotalItems() - 1);
@@ -4375,10 +4375,10 @@ export class ChatContainer extends Component {
 	syncMicSendVisibility(): void {
 		if (!this.micButton || !this.plugin.settings.whisperSettings?.enabled) return;
 		const isEmpty = (this.prompt ?? "").trim().length === 0;
-		this.micButton.buttonEl.style.display = isEmpty ? "" : "none";
+		this.micButton.buttonEl.toggleClass("llm-hidden", !isEmpty);
 		// Send button: opposite of mic — reach it as the next DOM sibling
 		const sendEl = this.micButton.buttonEl.nextElementSibling as HTMLElement | null;
-		if (sendEl) sendEl.style.display = isEmpty ? "none" : "";
+		if (sendEl) sendEl.toggleClass("llm-hidden", isEmpty);
 	}
 
 	/**
@@ -4395,13 +4395,13 @@ export class ChatContainer extends Component {
 		const sendEl = this.micButton.buttonEl.nextElementSibling as HTMLElement | null;
 		if (!enabled) {
 			// Hide the mic; make the send button unconditionally visible
-			this.micButton.buttonEl.style.display = "none";
-			if (sendEl) sendEl.style.display = "";
+			this.micButton.buttonEl.addClass("llm-hidden");
+			if (sendEl) sendEl.removeClass("llm-hidden");
 		} else {
 			// Restore normal visibility logic based on prompt content
 			const isEmpty = (this.prompt ?? "").trim().length === 0;
-			this.micButton.buttonEl.style.display = isEmpty ? "" : "none";
-			if (sendEl) sendEl.style.display = isEmpty ? "none" : "";
+			this.micButton.buttonEl.toggleClass("llm-hidden", !isEmpty);
+			if (sendEl) sendEl.toggleClass("llm-hidden", isEmpty);
 		}
 	}
 

--- a/src/Plugin/Components/ChatRowMenuHelper.ts
+++ b/src/Plugin/Components/ChatRowMenuHelper.ts
@@ -1,4 +1,5 @@
 import { App, ButtonComponent, Menu, Modal, Notice, TFile, setIcon } from "obsidian";
+import { logger } from "../../utils/logger";
 import LLMPlugin from "main";
 import { ConfirmDeleteModal } from "./ConfirmDeleteModal";
 
@@ -159,7 +160,7 @@ export function attachChatRowMenu(
 								);
 								onRefresh();
 							} catch (err) {
-								console.error("[ChatRowMenu] Failed to remove from project:", err);
+								logger.error("[ChatRowMenu] Failed to remove from project:", err);
 								new Notice("Failed to move conversation.");
 							}
 						}
@@ -184,7 +185,7 @@ export function attachChatRowMenu(
 									);
 									onRefresh();
 								} catch (err) {
-									console.error("[ChatRowMenu] Failed to move to project:", err);
+									logger.error("[ChatRowMenu] Failed to move to project:", err);
 									new Notice("Failed to move conversation.");
 								}
 							})
@@ -210,7 +211,7 @@ export function attachChatRowMenu(
 							await plugin.chatHistory.rename(file.path, newTitle);
 							onRefresh();
 						} catch (err) {
-							console.error("[ChatRowMenu] Failed to rename chat:", err);
+							logger.error("[ChatRowMenu] Failed to rename chat:", err);
 							new Notice("Failed to rename conversation.");
 						}
 					}).open();
@@ -229,7 +230,7 @@ export function attachChatRowMenu(
 							await plugin.chatHistory.delete(file.path);
 							onRefresh();
 						} catch (err) {
-							console.error("[ChatRowMenu] Failed to delete chat:", err);
+							logger.error("[ChatRowMenu] Failed to delete chat:", err);
 							new Notice("Failed to delete conversation.");
 						}
 					}).open();

--- a/src/Plugin/Components/ChatsSidebar.ts
+++ b/src/Plugin/Components/ChatsSidebar.ts
@@ -1,4 +1,5 @@
 import { Component, ExtraButtonComponent, Menu, SearchComponent, TFile, setIcon } from "obsidian";
+import { logger } from "../../utils/logger";
 import LLMPlugin from "main";
 import { attachChatRowMenu } from "./ChatRowMenuHelper";
 
@@ -126,7 +127,7 @@ export class ChatsSidebar extends Component {
 		try {
 			this.allFiles = await this.plugin.chatHistory.list();
 		} catch (e) {
-			console.error("[ChatsSidebar] Failed to list chat files:", e);
+			logger.error("[ChatsSidebar] Failed to list chat files:", e);
 			this.allFiles = [];
 		}
 		this.applyFilter();

--- a/src/Plugin/Components/Header.ts
+++ b/src/Plugin/Components/Header.ts
@@ -1,4 +1,5 @@
 import LLMPlugin from "main";
+import { logger } from "../../utils/logger";
 import { ButtonComponent, Menu } from "obsidian";
 import { ChatContainer } from "./ChatContainer";
 import { ConfirmDeleteModal } from "./ConfirmDeleteModal";
@@ -274,7 +275,7 @@ export class Header {
 									this.plugin.chatHistory
 										.delete(filePath)
 										.catch((e) =>
-											console.error("[Header] Failed to delete chat file:", e)
+											logger.error("[Header] Failed to delete chat file:", e)
 										);
 									setHistoryFilePath(this.plugin, this.viewType, null);
 								}
@@ -425,7 +426,7 @@ export class Header {
 									this.plugin.chatHistory
 										.delete(historyFilePath)
 										.catch((e) =>
-											console.error("[Header] Failed to delete chat file:", e)
+											logger.error("[Header] Failed to delete chat file:", e)
 										);
 									setHistoryFilePath(this.plugin, this.viewType, null);
 								}

--- a/src/Plugin/Components/HistoryContainer.ts
+++ b/src/Plugin/Components/HistoryContainer.ts
@@ -1,4 +1,5 @@
 import { HistoryItem, ViewType } from "Types/types";
+import { logger } from "../../utils/logger";
 import LLMPlugin, { DEFAULT_SETTINGS } from "main";
 import { ButtonComponent, Notice, TFile } from "obsidian";
 import { ConfirmDeleteModal } from "./ConfirmDeleteModal";
@@ -99,7 +100,7 @@ export class HistoryContainer {
 					);
 				})
 				.catch((e) => {
-					console.error("[HistoryContainer] Failed to list chat files:", e);
+					logger.error("[HistoryContainer] Failed to list chat files:", e);
 					this.displayNoHistoryView(parentElement);
 				});
 			return;
@@ -417,7 +418,7 @@ export class HistoryContainer {
 						chat.pushChatDetailsState();
 					})
 					.catch((e) => {
-						console.error("[HistoryContainer] Failed to load chat file:", e);
+						logger.error("[HistoryContainer] Failed to load chat file:", e);
 						new Notice("Failed to load conversation.");
 					});
 			};
@@ -467,7 +468,7 @@ export class HistoryContainer {
 							);
 						})
 						.catch((e) =>
-							console.error("[HistoryContainer] Failed to delete chat file:", e)
+							logger.error("[HistoryContainer] Failed to delete chat file:", e)
 						);
 				}).open();
 			});
@@ -507,7 +508,7 @@ export class HistoryContainer {
 						disableOtherItems(parentElement.children, index, false);
 					})
 					.catch((e) => {
-						console.error("[HistoryContainer] Failed to rename chat file:", e);
+						logger.error("[HistoryContainer] Failed to rename chat file:", e);
 						new Notice("Failed to rename conversation.");
 					});
 			});

--- a/src/Plugin/FAB/FAB.ts
+++ b/src/Plugin/FAB/FAB.ts
@@ -39,12 +39,10 @@ export class FAB {
 		const viewArea = fabContainer.createDiv();
 		viewArea.addClass("fab-view-area");
 
-		// Set properties independently so they never clobber each other.
-		// setAttr("style", ...) is intentionally avoided — it writes the whole
-		// attribute string atomically and then changing one property (display)
-		// later can race with or lose the other (height).
+		// Visibility is toggled via the .llm-hidden class so it can never clobber
+		// the inline height (the resize handle writes viewArea.style.height directly).
 		const savedHeight = this.plugin.settings.fabViewHeight ?? 600;
-		viewArea.style.display = "none";
+		viewArea.addClass("llm-hidden");
 		viewArea.style.height = `${savedHeight}px`;
 
 		this.fabViewArea = viewArea;
@@ -98,7 +96,7 @@ export class FAB {
 			chatContainer,
 			historyContainer,
 			settingsContainer,
-			() => { viewArea.style.display = "none"; }
+			() => { viewArea.addClass("llm-hidden"); }
 		);
 
 		resizeHandle.addEventListener("pointerdown", (e: PointerEvent) => {
@@ -147,9 +145,9 @@ export class FAB {
 
 		let history = this.plugin.settings.promptHistory;
 
-		settingsContainerDiv.setAttr("style", "display: none");
+		settingsContainerDiv.hide();
 		settingsContainerDiv.addClass("fab-settings-container", "llm-flex");
-		chatHistoryContainer.setAttr("style", "display: none");
+		chatHistoryContainer.hide();
 		chatHistoryContainer.addClass("fab-chat-history-container", "llm-flex");
 		lineBreak.className =
 			classNames["floating-action-button"]["title-border"];
@@ -170,8 +168,8 @@ export class FAB {
 			.setIcon("bot-message-square")
 			.setClass("buttonItem")
 			.onClick(() => {
-				if (viewArea.style.display === "none") {
-					viewArea.style.display = "flex";
+				if (viewArea.hasClass("llm-hidden")) {
+					viewArea.removeClass("llm-hidden");
 					// Sync the model dropdown to reflect any settings changes made
 					// while the FAB was closed (the container is built once, so it
 					// won't pick up new defaults automatically).
@@ -190,7 +188,7 @@ export class FAB {
 						}
 					});
 				} else {
-					viewArea.style.display = "none";
+					viewArea.addClass("llm-hidden");
 				}
 			});
 
@@ -242,8 +240,8 @@ export class FAB {
 		const settingType = getSettingType("floating-action-button") as "fabSettings";
 
 		// Show the FAB view area if it's currently hidden
-		if (this.fabViewArea?.style.display === "none") {
-			this.fabViewArea.style.display = "flex";
+		if (this.fabViewArea?.hasClass("llm-hidden")) {
+			this.fabViewArea.removeClass("llm-hidden");
 			this.chatContainer.syncModelDropdown();
 			requestAnimationFrame(() => {
 				if (!this.fabViewArea) return;

--- a/src/Plugin/FAB/FAB.ts
+++ b/src/Plugin/FAB/FAB.ts
@@ -1,4 +1,5 @@
 import { ChatContainer } from "Plugin/Components/ChatContainer";
+import { logger } from "../../utils/logger";
 import { Header } from "Plugin/Components/Header";
 import { HistoryContainer } from "Plugin/Components/HistoryContainer";
 import { SettingsContainer } from "Plugin/Components/SettingsContainer";
@@ -300,7 +301,7 @@ export class FAB {
 				this.chatContainer!.syncModelDropdown();
 			})
 			.catch((e) => {
-				console.error("[FAB] Failed to load chat file:", e);
+				logger.error("[FAB] Failed to load chat file:", e);
 				new Notice("Failed to load conversation.");
 			});
 	}

--- a/src/Plugin/Modal/ChatModal2.ts
+++ b/src/Plugin/Modal/ChatModal2.ts
@@ -24,7 +24,7 @@ export class ChatModal2 extends Modal {
 		this.plugin.settings.currentIndex = -1;
 		void this.plugin.saveSettings();
 		(this.modalEl.getElementsByClassName("modal-close-button")[0] as HTMLElement | undefined)
-			?.setAttr("style", "display: none");
+			?.addClass("llm-hidden");
 		const { contentEl } = this;
 		const header = new Header(this.plugin, "modal");
 		// Modal always gets a fresh store — each opening starts a new conversation.
@@ -56,9 +56,9 @@ export class ChatModal2 extends Modal {
 		);
 		let history = this.plugin.settings.promptHistory;
 
-		settingsContainerDiv.setAttr("style", "display: none");
+		settingsContainerDiv.hide();
 		settingsContainerDiv.addClass("llm-modal-settings-container", "llm-flex");
-		chatHistoryContainer.setAttr("style", "display: none");
+		chatHistoryContainer.hide();
 		chatHistoryContainer.addClass("llm-modal-chat-history-container", "llm-flex");
 		lineBreak.className = classNames["modal"]["title-border"];
 		chatContainerDiv.addClass("llm-modal-chat-container", "llm-flex");

--- a/src/Plugin/ObsidianAgent/ObsidianAgent.ts
+++ b/src/Plugin/ObsidianAgent/ObsidianAgent.ts
@@ -13,6 +13,7 @@
  */
 
 import { Notice, TFile } from "obsidian";
+import { logger } from "../../utils/logger";
 import LLMPlugin from "main";
 import { ObsidianToolRegistry } from "services/ObsidianToolRegistry";
 
@@ -129,7 +130,7 @@ export class ObsidianAgent {
 					}
 				}
 			} catch (e) {
-				console.warn("[ObsidianAgent] Could not read agent guidance file:", e);
+				logger.warn("[ObsidianAgent] Could not read agent guidance file:", e);
 			}
 		}
 

--- a/src/Plugin/StatusBar/RecentChatsButton.ts
+++ b/src/Plugin/StatusBar/RecentChatsButton.ts
@@ -26,7 +26,7 @@ export class RecentChatsButton {
 
 		this.popoverEl = document.body.createDiv();
 		this.popoverEl.addClass("llm-recent-chats-popover");
-		this.popoverEl.style.display = "none";
+		this.popoverEl.addClass("llm-hidden");
 
 		this.statusBarEl.addEventListener("click", (e: MouseEvent) => {
 			e.stopPropagation();
@@ -234,9 +234,9 @@ export class RecentChatsButton {
 	private togglePopover() {
 		if (!this.popoverEl) return;
 
-		if (this.popoverEl.style.display === "none") {
+		if (this.popoverEl.hasClass("llm-hidden")) {
 			this.renderPopoverContents();
-			this.popoverEl.style.display = "flex";
+			this.popoverEl.removeClass("llm-hidden");
 
 			requestAnimationFrame(() => this.repositionPopover());
 
@@ -265,7 +265,7 @@ export class RecentChatsButton {
 	}
 
 	private hidePopover() {
-		if (this.popoverEl) this.popoverEl.style.display = "none";
+		if (this.popoverEl) this.popoverEl.addClass("llm-hidden");
 		if (this.clickOutsideHandler) {
 			document.removeEventListener("click", this.clickOutsideHandler);
 			this.clickOutsideHandler = null;

--- a/src/Plugin/StatusBar/StatusBarButton.ts
+++ b/src/Plugin/StatusBar/StatusBarButton.ts
@@ -1,4 +1,5 @@
 import { ChatContainer } from "Plugin/Components/ChatContainer";
+import { logger } from "../../utils/logger";
 import { Header } from "Plugin/Components/Header";
 import { HistoryContainer } from "Plugin/Components/HistoryContainer";
 import { SettingsContainer } from "Plugin/Components/SettingsContainer";
@@ -418,7 +419,7 @@ export class StatusBarButton {
 				this.chatContainer!.syncModelDropdown();
 			})
 			.catch((e) => {
-				console.error("[StatusBarButton] Failed to load chat file:", e);
+				logger.error("[StatusBarButton] Failed to load chat file:", e);
 				new Notice("Failed to load conversation.");
 			});
 	}

--- a/src/Plugin/StatusBar/StatusBarButton.ts
+++ b/src/Plugin/StatusBar/StatusBarButton.ts
@@ -86,12 +86,12 @@ export class StatusBarButton {
 	private buildPopover() {
 		this.popoverEl = document.body.createDiv();
 		this.popoverEl.addClass("llm-status-bar-popover");
-		this.popoverEl.style.display = "none";
+		this.popoverEl.addClass("llm-hidden");
 
 		// Reposition whenever the window is resized or the Obsidian frame is
 		// moved (which fires a "resize" event on the window object).
 		this.boundRepositionHandler = () => {
-			if (this.popoverEl && this.popoverEl.style.display !== "none") {
+			if (this.popoverEl && !this.popoverEl.hasClass("llm-hidden")) {
 				this.repositionPopover();
 			}
 		};
@@ -148,9 +148,9 @@ export class StatusBarButton {
 			() => this.hidePopover()
 		);
 
-		settingsContainerDiv.setAttr("style", "display: none");
+		settingsContainerDiv.hide();
 		settingsContainerDiv.addClass("fab-settings-container", "llm-flex");
-		chatHistoryContainer.setAttr("style", "display: none");
+		chatHistoryContainer.hide();
 		chatHistoryContainer.addClass("fab-chat-history-container", "llm-flex");
 		chatContainerDiv.addClass("fab-chat-container", "llm-flex");
 
@@ -238,7 +238,7 @@ export class StatusBarButton {
 	private togglePopover() {
 		if (!this.popoverEl) return;
 
-		if (this.popoverEl.style.display === "none") {
+		if (this.popoverEl.hasClass("llm-hidden")) {
 			const { historyIndex } = getViewInfo(
 				this.plugin,
 				"floating-action-button"
@@ -247,7 +247,7 @@ export class StatusBarButton {
 			this.plugin.settings.currentIndex = historyIndex;
 			void this.plugin.saveSettings();
 
-			this.popoverEl.style.display = "flex";
+			this.popoverEl.removeClass("llm-hidden");
 
 			// Sync the model dropdown to reflect any default-model change made
 			// since the popover was first built (buildPopover runs once on load).
@@ -277,7 +277,7 @@ export class StatusBarButton {
 	}
 
 	private hidePopover() {
-		if (this.popoverEl) this.popoverEl.style.display = "none";
+		if (this.popoverEl) this.popoverEl.addClass("llm-hidden");
 	}
 
 	/**
@@ -306,9 +306,9 @@ export class StatusBarButton {
 		void this.plugin.saveSettings();
 
 		// Show the popover if it's currently hidden
-		if (this.popoverEl?.style.display === "none") {
+		if (this.popoverEl?.hasClass("llm-hidden")) {
 			setView(this.plugin, "floating-action-button");
-			this.popoverEl.style.display = "flex";
+			this.popoverEl.removeClass("llm-hidden");
 			this.chatContainer.refreshActiveFileChip();
 
 			requestAnimationFrame(() => {
@@ -352,9 +352,9 @@ export class StatusBarButton {
 		const settingType = getSettingType("floating-action-button");
 
 		// Show the popover if it's currently hidden
-		if (this.popoverEl?.style.display === "none") {
+		if (this.popoverEl?.hasClass("llm-hidden")) {
 			setView(this.plugin, "floating-action-button");
-			this.popoverEl.style.display = "flex";
+			this.popoverEl.removeClass("llm-hidden");
 			this.chatContainer.refreshActiveFileChip();
 
 			requestAnimationFrame(() => {

--- a/src/Plugin/Widget/Widget.ts
+++ b/src/Plugin/Widget/Widget.ts
@@ -1,4 +1,5 @@
 import { ChatContainer } from "Plugin/Components/ChatContainer";
+import { logger } from "../../utils/logger";
 import { ChatsSidebar } from "Plugin/Components/ChatsSidebar";
 import { Header } from "Plugin/Components/Header";
 import { HistoryContainer } from "Plugin/Components/HistoryContainer";
@@ -144,7 +145,7 @@ export class WidgetView extends ItemView {
 			// push here to make sure the model label is current.
 			this.chatContainer.pushChatDetailsState();
 		} catch (e) {
-			console.error("[WidgetView] Failed to load chat file:", e);
+			logger.error("[WidgetView] Failed to load chat file:", e);
 			new Notice("Failed to load conversation.");
 		}
 	}

--- a/src/Plugin/Widget/Widget.ts
+++ b/src/Plugin/Widget/Widget.ts
@@ -227,9 +227,9 @@ export class WidgetView extends ItemView {
 		const chatHistoryContainer = this.chatHistoryContainer;
 		const settingsContainerDiv = mainDiv.createDiv();
 
-		settingsContainerDiv.setAttr("style", "display: none");
+		settingsContainerDiv.hide();
 		settingsContainerDiv.addClass("llm-widget-settings-container", "llm-flex");
-		chatHistoryContainer.setAttr("style", "display: none");
+		chatHistoryContainer.hide();
 		chatHistoryContainer.addClass("llm-widget-chat-history-container", "llm-flex");
 		chatContainerDiv.addClass("llm-widget-chat-container", "llm-flex");
 

--- a/src/Projects/ProjectManager.ts
+++ b/src/Projects/ProjectManager.ts
@@ -24,6 +24,7 @@
  */
 
 import { App, TFile } from "obsidian";
+import { logger } from "../utils/logger";
 import { Project } from "Types/types";
 
 export class ProjectManager {
@@ -99,10 +100,10 @@ export class ProjectManager {
 			const project = ProjectManager.parseProjectFile(raw, filePath, this.projectsFolder);
 			if (project) {
 				this.projects.set(project.id, project);
-				console.log(`[ProjectManager] Loaded project: ${project.id} (${project.name})`);
+				logger.log(`[ProjectManager] Loaded project: ${project.id} (${project.name})`);
 			}
 		} catch (e) {
-			console.error(`[ProjectManager] Failed to parse ${filePath}:`, e);
+			logger.error(`[ProjectManager] Failed to parse ${filePath}:`, e);
 		}
 	}
 
@@ -176,7 +177,7 @@ created: ${created}
 			await this.loadProjectByPath(filePath);
 			return filePath;
 		} catch (e) {
-			console.error(`[ProjectManager] Failed to create project at ${filePath}:`, e);
+			logger.error(`[ProjectManager] Failed to create project at ${filePath}:`, e);
 			return null;
 		}
 	}
@@ -196,7 +197,7 @@ created: ${created}
 			}
 			this.projects.delete(id);
 		} catch (e) {
-			console.error(`[ProjectManager] Failed to delete project ${id}:`, e);
+			logger.error(`[ProjectManager] Failed to delete project ${id}:`, e);
 		}
 	}
 

--- a/src/RAG/EmbeddingService.ts
+++ b/src/RAG/EmbeddingService.ts
@@ -1,6 +1,6 @@
 import OpenAI from "openai";
+import { logger } from "../utils/logger";
 import { GoogleGenAI } from "@google/genai";
-import { join } from "path";
 
 export type EmbeddingProvider = "onnx" | "openai" | "gemini" | "ollama" | "lmStudio";
 
@@ -70,7 +70,7 @@ function downloadFile(
 					res.on("data", (c: Buffer) => { done += c.length; onBytes?.(done, total); });
 					res.pipe(ws);
 					ws.on("finish", resolve);
-					ws.on("error", (e: Error) => { try { fs.unlinkSync(destPath); } catch (_) {} reject(e); });
+					ws.on("error", (e: Error) => { try { fs.unlinkSync(destPath); } catch { /* ignore */ } reject(e); });
 					res.on("error", reject);
 				},
 			).on("error", reject).end();
@@ -106,6 +106,7 @@ class WordPieceTokenizer {
 	}
 
 	encode(text: string, maxLen = 512): { input_ids: number[]; attention_mask: number[] } {
+		// eslint-disable-next-line no-control-regex -- intentionally strips ASCII control chars
 		let t = text.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "").replace(/\s+/g, " ").trim();
 		if (this.lowercase) {
 			t = t.toLowerCase();
@@ -257,7 +258,7 @@ export class EmbeddingService {
 
 	static configure(pluginDir: string): void {
 		_pluginDir = pluginDir;
-		console.log("[RAG] EmbeddingService configured, pluginDir:", pluginDir);
+		logger.log("[RAG] EmbeddingService configured, pluginDir:", pluginDir);
 	}
 
 	static async loadOnnx(onProgress?: (pct: number) => void): Promise<void> {
@@ -277,32 +278,31 @@ export class EmbeddingService {
 			const modelDir = path.join(_pluginDir, "onnx-models", "Xenova", "all-mpnet-base-v2");
 			const tokJson  = JSON.parse(fs.readFileSync(path.join(modelDir, "tokenizer.json"), "utf8"));
 			_tokenizer = new WordPieceTokenizer(tokJson);
-			console.log("[RAG] Tokenizer loaded");
+			logger.log("[RAG] Tokenizer loaded");
 
 			// ── 3. Load onnxruntime-node (same require that works in the banner) ──
 			onProgress?.(80);
-			const ortPath = path.join(_pluginDir, "..", "Obsidian-LLM-Plugin", "node_modules", "onnxruntime-node");
 			// Prefer the banner-injected instance (already required, no double-load)
 			const ortSymbol = Symbol.for("onnxruntime");
 			if ((globalThis as any)[ortSymbol]) {
 				_ort = (globalThis as any)[ortSymbol] as OrtLike;
-				console.log("[RAG] Using banner-injected onnxruntime-node");
+				logger.log("[RAG] Using banner-injected onnxruntime-node");
 			} else {
 				// Derive ORT path from the plugin's own location
 				// _pluginDir = .../large-language-models  → ../Obsidian-LLM-Plugin/node_modules/onnxruntime-node
 				// We embed the absolute path at build time via __ORT_ABS_PATH__ below.
 				_ort = require("__ORT_ABS_PATH__") as OrtLike;
-				console.log("[RAG] Loaded onnxruntime-node directly");
+				logger.log("[RAG] Loaded onnxruntime-node directly");
 			}
 
 			// ── 4. Create inference session ───────────────────────────────
 			onProgress?.(85);
 			const onnxPath = path.join(modelDir, "onnx", "model_quantized.onnx");
-			console.log("[RAG] Creating InferenceSession from", onnxPath);
+			logger.log("[RAG] Creating InferenceSession from", onnxPath);
 			_session = await _ort.InferenceSession.create(onnxPath, {
 				executionProviders: ["cpu"],
 			});
-			console.log("[RAG] Session ready. Inputs:", _session.inputNames, "Outputs:", _session.outputNames);
+			logger.log("[RAG] Session ready. Inputs:", _session.inputNames, "Outputs:", _session.outputNames);
 			onProgress?.(100);
 		})().catch(e => { _loadPromise = null; throw e; });
 
@@ -327,11 +327,11 @@ export class EmbeddingService {
 			if (fs.existsSync(dest)) {
 				completedBytes += FILE_SIZES[file] ?? 0;
 				onProgress?.((completedBytes / totalEstimated) * 100);
-				console.log("[RAG] Already cached:", file);
+				logger.log("[RAG] Already cached:", file);
 				continue;
 			}
 			const url = `${BASE_URL}/${file}`;
-			console.log("[RAG] Downloading:", file);
+			logger.log("[RAG] Downloading:", file);
 			const est  = FILE_SIZES[file] ?? 0;
 			const base = completedBytes;
 			await downloadFile(url, dest, (dl, total) => {
@@ -341,7 +341,7 @@ export class EmbeddingService {
 			});
 			completedBytes += est;
 			onProgress?.((completedBytes / totalEstimated) * 100);
-			console.log("[RAG] Downloaded:", file);
+			logger.log("[RAG] Downloaded:", file);
 		}
 	}
 

--- a/src/RAG/VectorStore.ts
+++ b/src/RAG/VectorStore.ts
@@ -1,4 +1,5 @@
 import { App } from "obsidian";
+import { logger } from "../utils/logger";
 
 export interface VectorChunk {
 	text: string;
@@ -32,7 +33,7 @@ export class VectorStore {
 			const raw = await this.app.vault.adapter.read(this.indexPath);
 			const parsed: IndexFile = JSON.parse(raw);
 			if (parsed.version !== INDEX_VERSION) {
-				console.warn("[RAG] Index version mismatch — rebuilding");
+				logger.warn("[RAG] Index version mismatch — rebuilding");
 				this.entries.clear();
 				this.loaded = true;
 				return;

--- a/src/Settings/LLMSettingsModal.ts
+++ b/src/Settings/LLMSettingsModal.ts
@@ -159,7 +159,7 @@ export class LLMSettingsModal extends Modal {
 		// Hide our scrim so we look like part of the core settings panel.
 		const modalBg = modalEl.closest(".modal-container")
 			?.querySelector<HTMLElement>(".modal-bg");
-		if (modalBg) modalBg.style.display = "none";
+		if (modalBg) modalBg.addClass("llm-hidden");
 
 		// Apply sizing now and on every window resize.
 		this.matchCoreModal();
@@ -1200,7 +1200,7 @@ export class LLMSettingsModal extends Modal {
 			migrationEl.empty();
 			if (!this.plugin.settings.chatHistoryEnabled) {
 				// Legacy mode — show the reset button for old promptHistory entries.
-				migrationGroup.style.display = "";
+				migrationGroup.removeClass("llm-hidden");
 				new Setting(migrationEl)
 					.setName("Reset legacy chat history")
 					.setDesc("Clears the old in-settings chat history only. Your saved markdown chat files in your vault are not affected.")
@@ -1213,7 +1213,7 @@ export class LLMSettingsModal extends Modal {
 					});
 				return;
 			}
-			migrationGroup.style.display = "";
+			migrationGroup.removeClass("llm-hidden");
 
 			new Setting(migrationEl)
 				.setName("New chat file location")

--- a/src/Skills/SkillRegistry.ts
+++ b/src/Skills/SkillRegistry.ts
@@ -25,6 +25,7 @@
  */
 
 import { App, TFile } from "obsidian";
+import { logger } from "../utils/logger";
 import { BUILTIN_SKILLS } from "./BuiltinSkills";
 
 export interface ParsedSkill {
@@ -107,7 +108,7 @@ export class SkillRegistry {
 			}
 
 			await adapter.write(skillFile, skill.content);
-			console.log(`[SkillRegistry] Seeded built-in skill: ${skill.id}`);
+			logger.log(`[SkillRegistry] Seeded built-in skill: ${skill.id}`);
 		}
 	}
 
@@ -158,10 +159,10 @@ export class SkillRegistry {
 			const skill = SkillRegistry.parseSkillFile(raw, filePath, this.skillsFolder);
 			if (skill) {
 				this.skills.set(skill.id, skill);
-				console.log(`[SkillRegistry] Loaded skill: ${skill.id} (${skill.name})`);
+				logger.log(`[SkillRegistry] Loaded skill: ${skill.id} (${skill.name})`);
 			}
 		} catch (e) {
-			console.error(`[SkillRegistry] Failed to parse ${filePath}:`, e);
+			logger.error(`[SkillRegistry] Failed to parse ${filePath}:`, e);
 		}
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import { Plugin, WorkspaceLeaf, Platform, addIcon, Notice } from "obsidian";
+import { logger } from "./utils/logger";
 import {
 	AssistantSettings,
 	FeatureSettings,
@@ -381,7 +382,7 @@ export default class LLMPlugin extends Plugin {
 		this.initVaultIndexer();
 		if (this.settings.ragSettings?.enabled && this.settings.ragSettings?.modelCached
 				&& (this.settings.ragSettings?.embeddingProvider ?? "onnx") === "onnx") {
-			EmbeddingService.loadOnnx().catch(e => console.error("[RAG] Failed to warm up ONNX model:", e));
+			EmbeddingService.loadOnnx().catch(e => logger.error("[RAG] Failed to warm up ONNX model:", e));
 		}
 		this.initMemoryService();
 		this.initWhisperService();
@@ -638,9 +639,9 @@ export default class LLMPlugin extends Plugin {
 						this.settings.ragSettings.lastIndexed = Date.now();
 						this.settings.ragSettings.indexedFileCount = this.vaultIndexer!.indexedFileCount;
 						await this.saveSettings();
-						console.log("[RAG] Auto-reindexed:", path);
+						logger.log("[RAG] Auto-reindexed:", path);
 					} catch (e) {
-						console.error("[RAG] Auto-reindex failed for", path, e);
+						logger.error("[RAG] Auto-reindex failed for", path, e);
 					}
 				}, DEBOUNCE_MS);
 
@@ -666,7 +667,7 @@ export default class LLMPlugin extends Plugin {
 						await this.saveSettings();
 					})
 					.catch((e) => {
-						console.error("[RAG] Failed to remove deleted file from index:", file.path, e);
+						logger.error("[RAG] Failed to remove deleted file from index:", file.path, e);
 					});
 			})
 		);
@@ -685,7 +686,7 @@ export default class LLMPlugin extends Plugin {
 						this.settings.ragSettings.indexedFileCount = this.vaultIndexer!.indexedFileCount;
 						await this.saveSettings();
 					})
-					.catch((e) => console.error("[RAG] Failed to reindex renamed file:", e));
+					.catch((e) => logger.error("[RAG] Failed to reindex renamed file:", e));
 			})
 		);
 	}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Plugin, WorkspaceLeaf, Platform, addIcon, Notice } from "obsidian";
+import { Plugin, WorkspaceLeaf, Platform, addIcon, Notice, normalizePath, TFile } from "obsidian";
 import { logger } from "./utils/logger";
 import {
 	AssistantSettings,
@@ -625,7 +625,7 @@ export default class LLMPlugin extends Plugin {
 		this.registerEvent(
 			this.app.vault.on("modify", (file) => {
 				if (!this.vaultIndexer || !this.settings.ragSettings?.enabled) return;
-				if (!(file as any).extension || (file as any).extension !== "md") return;
+				if (!(file instanceof TFile) || file.extension !== "md") return;
 
 				const path = file.path;
 				const existing = this.ragDebounceTimers.get(path);
@@ -634,7 +634,7 @@ export default class LLMPlugin extends Plugin {
 				const timer = activeWindow.setTimeout(async () => {
 					this.ragDebounceTimers.delete(path);
 					try {
-						await this.vaultIndexer!.indexFile(file as import("obsidian").TFile);
+						await this.vaultIndexer!.indexFile(file);
 						await this.vaultIndexer!.save();
 						this.settings.ragSettings.lastIndexed = Date.now();
 						this.settings.ragSettings.indexedFileCount = this.vaultIndexer!.indexedFileCount;
@@ -652,7 +652,7 @@ export default class LLMPlugin extends Plugin {
 		this.registerEvent(
 			this.app.vault.on("delete", (file) => {
 				if (!this.vaultIndexer || !this.settings.ragSettings?.enabled) return;
-				if ((file as any).extension !== "md") return;
+				if (!(file instanceof TFile) || file.extension !== "md") return;
 
 				// Cancel any pending reindex for this file
 				const timer = this.ragDebounceTimers.get(file.path);
@@ -675,11 +675,11 @@ export default class LLMPlugin extends Plugin {
 		this.registerEvent(
 			this.app.vault.on("rename", (file, oldPath) => {
 				if (!this.vaultIndexer || !this.settings.ragSettings?.enabled) return;
-				if ((file as any).extension !== "md") return;
+				if (!(file instanceof TFile) || file.extension !== "md") return;
 
 				// Remove old path, re-index under new path
 				this.vaultIndexer.removeFile(oldPath).catch(() => {});
-				this.vaultIndexer.indexFile(file as import("obsidian").TFile)
+				this.vaultIndexer.indexFile(file)
 					.then(async () => {
 						await this.vaultIndexer!.save();
 						this.settings.ragSettings.lastIndexed = Date.now();
@@ -720,7 +720,7 @@ export default class LLMPlugin extends Plugin {
 	 */
 	get skillsFolder(): string {
 		return this.settings.rootVaultFolder
-			? this.settings.rootVaultFolder + "/Skills"
+			? normalizePath(this.settings.rootVaultFolder + "/Skills")
 			: "";
 	}
 
@@ -729,7 +729,7 @@ export default class LLMPlugin extends Plugin {
 	 */
 	get memoriesFolder(): string {
 		return this.settings.rootVaultFolder
-			? this.settings.rootVaultFolder + "/Memories"
+			? normalizePath(this.settings.rootVaultFolder + "/Memories")
 			: "";
 	}
 
@@ -738,7 +738,7 @@ export default class LLMPlugin extends Plugin {
 	 */
 	get projectsFolder(): string {
 		return this.settings.rootVaultFolder
-			? this.settings.rootVaultFolder + "/Projects"
+			? normalizePath(this.settings.rootVaultFolder + "/Projects")
 			: "";
 	}
 
@@ -747,7 +747,7 @@ export default class LLMPlugin extends Plugin {
 	 */
 	get assistantsFolder(): string {
 		return this.settings.rootVaultFolder
-			? this.settings.rootVaultFolder + "/Assistants"
+			? normalizePath(this.settings.rootVaultFolder + "/Assistants")
 			: "";
 	}
 

--- a/src/services/ChatHistory.ts
+++ b/src/services/ChatHistory.ts
@@ -1,4 +1,5 @@
 import { Notice, TFile, parseYaml } from "obsidian";
+import { logger } from "../utils/logger";
 import LLMPlugin from "main";
 import { ChatHistoryItem, HistoryItem, Message, ToolCallRecord, VaultContext } from "Types/types";
 
@@ -614,7 +615,7 @@ export class ChatHistory {
 				);
 				migrated++;
 			} catch (e) {
-				console.error("[ChatHistory] Failed to migrate item:", e);
+				logger.error("[ChatHistory] Failed to migrate item:", e);
 				skipped++;
 			}
 		}
@@ -641,7 +642,7 @@ export class ChatHistory {
 				const result = await generator();
 				if (result?.trim()) return result.trim();
 			} catch (e) {
-				console.warn("[ChatHistory] Title generation failed, using fallback:", e);
+				logger.warn("[ChatHistory] Title generation failed, using fallback:", e);
 			}
 		}
 

--- a/src/services/ContextBuilder.ts
+++ b/src/services/ContextBuilder.ts
@@ -1,4 +1,5 @@
 import { App, MarkdownView, TFile } from "obsidian";
+import { logger } from "../utils/logger";
 import { ContextSettings, VaultContext } from "Types/types";
 
 export class ContextBuilder {
@@ -27,7 +28,7 @@ export class ContextBuilder {
 					};
 					hasContext = true;
 				} catch (error) {
-					console.error("Error reading active file:", error);
+					logger.error("Error reading active file:", error);
 				}
 			}
 		}
@@ -59,7 +60,7 @@ export class ContextBuilder {
 						hasContext = true;
 					}
 				} catch (error) {
-					console.error(`Error reading file ${filePath}:`, error);
+					logger.error(`Error reading file ${filePath}:`, error);
 				}
 			}
 		}

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,38 @@
+// Dev-gated logger.
+//
+// esbuild replaces `__DEV__` with the literal `true` (dev / watch build) or
+// `false` (production build) via the `define` block in esbuild.config.mjs.
+// `debug` / `log` / `info` are silenced in production to keep the console
+// clean — an Obsidian community-plugin review guideline. `warn` / `error`
+// always emit so user-reported production issues stay diagnosable.
+//
+// Usage: `import { logger } from "<rel>/utils/logger";` then `logger.log(...)`.
+
+declare const __DEV__: boolean;
+
+const isDev = typeof __DEV__ !== "undefined" && __DEV__;
+const PREFIX = "[LLM]";
+
+class Logger {
+	debug(...args: unknown[]): void {
+		if (isDev) console.debug(PREFIX, ...args);
+	}
+
+	log(...args: unknown[]): void {
+		if (isDev) console.log(PREFIX, ...args);
+	}
+
+	info(...args: unknown[]): void {
+		if (isDev) console.info(PREFIX, ...args);
+	}
+
+	warn(...args: unknown[]): void {
+		console.warn(PREFIX, ...args);
+	}
+
+	error(...args: unknown[]): void {
+		console.error(PREFIX, ...args);
+	}
+}
+
+export const logger = new Logger();

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,5 @@
 import LLMPlugin from "main";
+import { logger } from "./logger";
 import { Editor, Platform, requestUrl, RequestUrlParam } from "obsidian";
 import OpenAI from "openai";
 import Anthropic from "@anthropic-ai/sdk";
@@ -250,7 +251,7 @@ export async function getApiKeyValidity(providerKeyPair: ProviderKeyPair) {
 		}
 	} catch (error) {
 		if (error.status === 401) {
-			console.error(`Invalid API key for ${providerKeyPair.provider}.`);
+			logger.error(`Invalid API key for ${providerKeyPair.provider}.`);
 			SingletonNotice.show(
 				`Invalid API key for ${upperCaseFirst(
 					providerKeyPair.provider
@@ -296,6 +297,44 @@ export async function geminiMessage(
 
 // Resolve the absolute path to `node` by checking common install locations.
 // Electron's renderer process has a limited PATH, so we check the filesystem directly.
+function resolveNodePath(): string {
+	if (!Platform.isDesktop) return "";
+	const fs = require("fs");
+	const homedir = require("os").homedir();
+	const candidates: string[] = [];
+
+	// nvm — pick the latest installed version
+	const nvmDir = `${homedir}/.nvm/versions/node`;
+	try {
+		if (fs.existsSync(nvmDir)) {
+			const versions = fs.readdirSync(nvmDir).sort().reverse();
+			if (versions.length > 0) {
+				candidates.push(`${nvmDir}/${versions[0]}/bin/node`);
+			}
+		}
+	} catch { /* ignore */ }
+
+	candidates.push(
+		`${homedir}/.volta/bin/node`,                       // volta
+		`${homedir}/.local/share/fnm/aliases/default/bin/node`, // fnm
+		`${homedir}/.asdf/shims/node`,                      // asdf
+		`${homedir}/.local/bin/node`,
+		"/usr/local/bin/node",
+		"/usr/bin/node",
+		"/snap/bin/node",
+	);
+
+	for (const candidate of candidates) {
+		try {
+			if (fs.existsSync(candidate)) {
+				return candidate;
+			}
+		} catch { /* ignore */ }
+	}
+
+	logger.warn("[Claude Code] Could not find node binary, falling back to 'node'");
+	return "node";
+}
 
 export async function claudeCodeMessage(
 	prompt: string,

--- a/styles.css
+++ b/styles.css
@@ -1382,8 +1382,10 @@ button.llm-scan-button.is-active:hover {
 	box-shadow: none;
 }
 
-button.llm-scan-button.llm-hidden {
-	display: none;
+/* Generic visibility utility — toggle with el.toggleClass("llm-hidden", …).
+   !important so it overrides a base class's own display (flex/block). */
+.llm-hidden {
+	display: none !important;
 }
 
 /* STATUS BAR BUTTON */


### PR DESCRIPTION
Brings the plugin closer to Obsidian's community-plugin review guidelines, modeled on the fixes already shipped in the sister plugins (`obsidian-bluesky`, `obsidian-content-os`). Four focused commits.

## Changes

**1. Dev-gated logger + lint + bot-review fixes** (`937b2ea`)
- New `src/utils/logger.ts`; `__DEV__` wired via esbuild `define`. `debug/log/info` are stripped from production builds; `warn/error` always emit with an `[LLM]` prefix.
- All **75** `console.*` calls across 20 files → `logger.*`.
- Added `npm run lint` / `lint:fix` (`eslint src`) and fixed the 7 pre-existing lint errors.

**2. Inline display styles → `.llm-hidden` utility** (`a7906b0`)
- Generalized the scan-button-scoped `.llm-hidden` rule into a global `.llm-hidden { display: none !important }` utility (already the codebase convention via `toggleClass`).
- Converted ~**55** `.style.display` reads/writes to class toggles across FAB, StatusBar, RecentChats, ChatContainer, LLMSettingsModal.
- Header-managed settings/history containers now init via Obsidian's native `.hide()` (paired with Header's `.show()/.hide()`).

**3. Best-practice lint rules + normalizePath + instanceof** (`657f1c0`)
- Re-enabled `prefer-const`, `eqeqeq` (smart), `no-console` as **warnings** (lint stays green; `logger.ts` exempt from `no-console`).
- `normalizePath()` on the `rootVaultFolder`-derived folder getters.
- `(file as any).extension` → `instanceof TFile` (also dropped 2 redundant casts).

**4. Encode the patterns as rules/docs** (`92cf8ad`)
- New path-scoped `.claude/rules/obsidian-styling.md` + a CLAUDE.md "Obsidian Compliance Conventions" section.

## Scorecard

| | before | after |
|---|---|---|
| raw `console.*` in src | 75 | **0** |
| `.style.display` in src | ~53 | **0** |
| `innerHTML` | 0 | **0** |
| `npm run lint` | (no script) | **exit 0** (13 warnings) |
| `npm run build` | ✓ | **✓** |

## Deliberately deferred
- Dynamic inline styles (resize heights, popover positions, measurement mirrors) — Obsidian's guideline exempts dynamic values.
- The legacy in-settings `HistoryContainer` `setAttr("style",…)` cluster (only active when `chatHistoryEnabled: false`) — better moved to CSS `:hover`.
- ~27 `as any` — justified Obsidian-internal access (`app`/`vault.adapter`/`workspace`) lacking public types.

## Testing
`npm run build` and `npm run lint` both pass. The display→class conversions touch interactive UI (FAB panel, status-bar popover, recent-chats popover, slash menu, context chips, mic/send swap) — recommend a quick manual open/close/resize smoke-test of each before merge. One intentional behavior fix: the Whisper setup-log `<pre>` is now correctly hidden until it has output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)