### PR TITLE
feat: local filesystem tools, /attach slash command, agent UX improvements

### DIFF
--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -192,6 +192,11 @@ export class ChatContainer extends Component {
 	 * prevents other views' generateChatContainer calls from removing it.
 	 */
 	private slashMenuEl: HTMLElement | null = null;
+	/**
+	 * Local filesystem paths (files or folders) attached via the /attach slash
+	 * command. Injected as context at send time. Cleared on newChat().
+	 */
+	localContextPaths: { label: string; absPath: string; isDir: boolean }[] = [];
 
 	/**
 	 * When true, memories are recalled before each send and (if extraction
@@ -983,6 +988,83 @@ export class ChatContainer extends Component {
 				}
 			} catch (error) {
 				console.error("Error reading active file for context:", error);
+			}
+		}
+
+		// Local filesystem context from /attach slash command
+		if (this.localContextPaths.length > 0 && modelEndpoint !== images) {
+			try {
+				const nodeFs = require("fs") as typeof import("fs");
+				const nodePath = require("path") as typeof import("path");
+				const MAX_FILE_BYTES = 200_000;
+				const MAX_DIR_ENTRIES = 200;
+				const blocks: string[] = [];
+
+				for (const entry of this.localContextPaths) {
+					if (entry.isDir) {
+						// Directory: inject a recursive listing of source/text files
+						const walk = (dir: string, depth: number): string[] => {
+							if (depth > 6) return [];
+							let items: string[];
+							try { items = nodeFs.readdirSync(dir); } catch { return []; }
+							const result: string[] = [];
+							for (const item of items) {
+								if (item.startsWith(".") || item === "node_modules") continue;
+								const full = nodePath.join(dir, item);
+								let st: import("fs").Stats;
+								try { st = nodeFs.statSync(full); } catch { continue; }
+								if (st.isDirectory()) {
+									result.push(...walk(full, depth + 1));
+								} else {
+									result.push(full);
+								}
+							}
+							return result;
+						};
+						const allFiles = walk(entry.absPath, 0).slice(0, MAX_DIR_ENTRIES);
+						const listing = allFiles.map((f) => "  " + nodePath.relative(entry.absPath, f)).join("\n");
+						const TEXT_EXTS = new Set(["ts", "tsx", "js", "jsx", "mjs", "cjs", "json", "md", "css", "html", "yaml", "yml", "toml", "txt", "py", "sh", "swift", "kt", "java", "go", "rs", "c", "cpp", "h"]);
+						const fileBlocks: string[] = [];
+						for (const f of allFiles) {
+							const ext = nodePath.extname(f).replace(/^\./, "").toLowerCase();
+							if (!TEXT_EXTS.has(ext)) continue;
+							try {
+								const fd = nodeFs.openSync(f, "r");
+								const buf = Buffer.alloc(MAX_FILE_BYTES);
+								const read = nodeFs.readSync(fd, buf, 0, MAX_FILE_BYTES, 0);
+								nodeFs.closeSync(fd);
+								const rel = nodePath.relative(entry.absPath, f);
+								fileBlocks.push(`### ${rel}\n\`\`\`${ext}\n${buf.subarray(0, read).toString("utf8")}\n\`\`\``);
+							} catch { continue; }
+						}
+						blocks.push(
+							`# Attached folder: ${entry.label} (${entry.absPath})\n\n## File listing\n\`\`\`\n${listing}\n\`\`\`\n\n## File contents\n\n` +
+							(fileBlocks.length > 0 ? fileBlocks.join("\n\n") : "(no readable text files found)")
+						);
+					} else {
+						// Single file
+						try {
+							const fd = nodeFs.openSync(entry.absPath, "r");
+							const buf = Buffer.alloc(MAX_FILE_BYTES);
+							const st = nodeFs.statSync(entry.absPath);
+							const read = nodeFs.readSync(fd, buf, 0, MAX_FILE_BYTES, 0);
+							nodeFs.closeSync(fd);
+							const ext = nodePath.extname(entry.absPath).replace(/^\./, "").toLowerCase();
+							const truncNote = read === MAX_FILE_BYTES && st.size > MAX_FILE_BYTES ? ` (truncated to first ${MAX_FILE_BYTES} bytes)` : "";
+							blocks.push(`# Attached file: ${entry.label} (${entry.absPath})${truncNote}\n\n\`\`\`${ext}\n${buf.subarray(0, read).toString("utf8")}\n\`\`\``);
+						} catch (e) {
+							blocks.push(`# Attached file: ${entry.label}\n\n(Error reading file: ${e})`);
+						}
+					}
+				}
+
+				if (blocks.length > 0) {
+					const localContext = blocks.join("\n\n---\n\n");
+					this.pendingContextString = localContext +
+						(this.pendingContextString ? "\n\n---\n\n" + this.pendingContextString : "");
+				}
+			} catch (err) {
+				console.error("[LLM] Error reading local context paths:", err);
 			}
 		}
 
@@ -2546,8 +2628,9 @@ export class ChatContainer extends Component {
 		const hasAdditional = this.plugin.settings.enableFileContext && contextSettings.selectedFiles.length > 0;
 		const hasPinned = pinnedNotes.length > 0;
 		const hasProject = !!activeProject;
+		const hasLocalPaths = this.localContextPaths.length > 0;
 
-		if (!hasActiveFile && !hasAdditional && !hasPinned && !hasProject) {
+		if (!hasActiveFile && !hasAdditional && !hasPinned && !hasProject && !hasLocalPaths) {
 			this.chipContainer.style.display = "none";
 			return;
 		}
@@ -2587,6 +2670,19 @@ export class ChatContainer extends Component {
 					void this.plugin.saveSettings();
 					this.syncChips();
 				});
+			}
+		}
+
+		// Local filesystem path chips (from /attach slash command)
+		for (const entry of [...this.localContextPaths]) {
+			const chip = this.buildChip(this.chipContainer, entry.label, () => {
+				this.localContextPaths = this.localContextPaths.filter((p) => p.absPath !== entry.absPath);
+				this.syncChips();
+			});
+			// Swap the file icon for a folder icon when the entry is a directory
+			if (entry.isDir) {
+				const iconEl = chip.querySelector<HTMLElement>(".llm-context-chip-icon");
+				if (iconEl) setIcon(iconEl, "folder");
 			}
 		}
 	}
@@ -2790,19 +2886,47 @@ export class ChatContainer extends Component {
 		});
 		cleanupObserver.observe(document.body, { childList: true, subtree: false });
 
-		const renderSlashMenu = (skills: ParsedSkill[]) => {
+		// "Attach local path" is a built-in slash command that opens the OS file picker.
+		// It matches /attach (and any prefix like /att, /a, /).
+		const LOCAL_PATH_COMMAND = { id: "attach", name: "Attach local file or folder", description: "Open your file system to pick a file or folder to add as context" };
+		const localPathMatchesQuery = (query: string) => LOCAL_PATH_COMMAND.id.startsWith(query) || LOCAL_PATH_COMMAND.name.toLowerCase().startsWith(query);
+
+		const renderSlashMenu = (skills: ParsedSkill[], query: string) => {
 			slashMenu.empty();
 			slashMenuSkills = skills;
+			// Total items = local-path entry (if visible) + skills
+			const showLocalPath = localPathMatchesQuery(query);
+			// Index mapping: 0 = local path item (if shown), then skills
 			slashMenuIndex = 0;
-			if (skills.length === 0) { slashMenu.style.display = "none"; return; }
+			const totalItems = (showLocalPath ? 1 : 0) + skills.length;
+			if (totalItems === 0) { slashMenu.style.display = "none"; return; }
 
-			// Header label
-			slashMenu.createDiv({ cls: "llm-slash-menu-header", text: "Skills" });
+			if (showLocalPath) {
+				if (skills.length > 0) {
+					slashMenu.createDiv({ cls: "llm-slash-menu-header", text: "Actions" });
+				}
+				const item = slashMenu.createDiv({ cls: "llm-slash-menu-item llm-slash-menu-item-selected" });
+				const iconEl = item.createSpan({ cls: "llm-slash-menu-item-icon" });
+				setIcon(iconEl, "folder-open");
+				const textEl = item.createDiv({ cls: "llm-slash-menu-item-text" });
+				const nameRow = textEl.createDiv({ cls: "llm-slash-menu-item-name-row" });
+				nameRow.createSpan({ cls: "llm-slash-menu-item-name", text: LOCAL_PATH_COMMAND.name });
+				textEl.createDiv({ cls: "llm-slash-menu-item-desc", text: LOCAL_PATH_COMMAND.description });
+				item.addEventListener("mousedown", (e: MouseEvent) => {
+					e.preventDefault();
+					selectLocalPathFromMenu();
+				});
+			}
+
+			if (skills.length > 0) {
+				slashMenu.createDiv({ cls: "llm-slash-menu-header", text: "Skills" });
+			}
 
 			for (let i = 0; i < skills.length; i++) {
 				const skill = skills[i];
+				const globalIdx = (showLocalPath ? 1 : 0) + i;
 				const item = slashMenu.createDiv({ cls: "llm-slash-menu-item" });
-				if (i === 0) item.addClass("llm-slash-menu-item-selected");
+				if (!showLocalPath && i === 0) item.addClass("llm-slash-menu-item-selected");
 
 				const iconEl = item.createSpan({ cls: "llm-slash-menu-item-icon" });
 				setIcon(iconEl, "scroll-text");
@@ -2841,10 +2965,57 @@ export class ChatContainer extends Component {
 					e.preventDefault(); // keep textarea focused
 					selectSkillFromMenu(skill);
 				});
+
+				// Store globalIdx on the element so updateSlashMenuHighlight can compare
+				item.dataset.menuIndex = String(globalIdx);
 			}
 
 			slashMenu.style.display = "flex";
 			positionSlashMenu();
+		};
+
+		const selectLocalPathFromMenu = () => {
+			hideSlashMenu();
+			// Clear the typed /attach prefix from the input so the user can keep typing
+			const raw = promptField.getValue();
+			const cleaned = raw.replace(/^\/[a-zA-Z0-9_-]*\s*/, "");
+			promptField.setValue(cleaned);
+			this.prompt = cleaned;
+			syncMirror(cleaned);
+			updateSendButton(cleaned);
+			promptField.inputEl.focus();
+
+			// Open native OS file/folder picker via Electron
+			try {
+				const { remote } = require("electron") as any;
+				const nodePath = require("path") as typeof import("path");
+				const lastDir = (this.plugin.settings as any).lastLocalPickerDirectory || undefined;
+				remote.dialog.showOpenDialog({
+					title: "Attach file or folder",
+					defaultPath: lastDir,
+					buttonLabel: "Attach",
+					properties: ["openFile", "openDirectory"],
+				}).then((result: { canceled: boolean; filePaths: string[] }) => {
+					if (result.canceled || result.filePaths.length === 0) return;
+					const absPath = result.filePaths[0];
+
+					// Persist last-used directory
+					const nodeFs = require("fs") as typeof import("fs");
+					const isDir = nodeFs.statSync(absPath).isDirectory();
+					(this.plugin.settings as any).lastLocalPickerDirectory = isDir ? absPath : nodePath.dirname(absPath);
+					void this.plugin.saveSettings();
+
+					const label = nodePath.basename(absPath);
+					// Avoid duplicates
+					if (this.localContextPaths.some((p) => p.absPath === absPath)) return;
+					this.localContextPaths.push({ label, absPath, isDir });
+					this.syncChips();
+				}).catch((err: Error) => {
+					console.error("[LLM] File picker error:", err);
+				});
+			} catch (err) {
+				console.error("[LLM] Electron dialog unavailable:", err);
+			}
 		};
 
 		const hideSlashMenu = () => {
@@ -2859,6 +3030,22 @@ export class ChatContainer extends Component {
 				el.toggleClass("llm-slash-menu-item-selected", i === slashMenuIndex);
 				if (i === slashMenuIndex) el.scrollIntoView({ block: "nearest" });
 			});
+		};
+
+		// Returns total items currently rendered in the slash menu
+		const slashMenuTotalItems = () => slashMenu.querySelectorAll<HTMLElement>(".llm-slash-menu-item").length;
+
+		const selectCurrentSlashMenuItem = () => {
+			const items = slashMenu.querySelectorAll<HTMLElement>(".llm-slash-menu-item");
+			const selectedEl = items[slashMenuIndex];
+			if (!selectedEl) return;
+			// Local path item has no data-menu-index; skill items do
+			if (selectedEl.dataset.menuIndex === undefined) {
+				selectLocalPathFromMenu();
+			} else {
+				const skillIdx = parseInt(selectedEl.dataset.menuIndex, 10) - (items[0]?.dataset.menuIndex === undefined ? 1 : 0);
+				if (slashMenuSkills[skillIdx]) selectSkillFromMenu(slashMenuSkills[skillIdx]);
+			}
 		};
 
 		const selectSkillFromMenu = (skill: ParsedSkill) => {
@@ -3362,7 +3549,7 @@ export class ChatContainer extends Component {
 							s.name.toLowerCase().startsWith(query)
 					  )
 					: allSkills;
-				renderSlashMenu(filtered);
+				renderSlashMenu(filtered, query);
 			} else {
 				hideSlashMenu();
 			}
@@ -3384,7 +3571,7 @@ export class ChatContainer extends Component {
 			if (slashMenu.style.display !== "none") {
 				if (event.key === "ArrowDown") {
 					event.preventDefault();
-					slashMenuIndex = Math.min(slashMenuIndex + 1, slashMenuSkills.length - 1);
+					slashMenuIndex = Math.min(slashMenuIndex + 1, slashMenuTotalItems() - 1);
 					updateSlashMenuHighlight();
 					return;
 				}
@@ -3396,10 +3583,8 @@ export class ChatContainer extends Component {
 				}
 				if (event.key === "Tab" || event.key === "Enter") {
 					event.preventDefault();
-					if (slashMenuSkills[slashMenuIndex]) {
-						selectSkillFromMenu(slashMenuSkills[slashMenuIndex]);
-					}
-					return; // Tab/Enter selects skill; Enter does NOT send
+					selectCurrentSlashMenuItem();
+					return; // Tab/Enter selects item; Enter does NOT send
 				}
 				if (event.key === "Escape") {
 					event.preventDefault();
@@ -4586,6 +4771,7 @@ export class ChatContainer extends Component {
 		// Without this, toggling the setting or switching chats left stale chip state.
 		this.useActiveFileContext = false;
 		this.activeFileForChip = null;
+		this.localContextPaths = [];
 		this.scanButton?.buttonEl.removeClass("is-active");
 
 		const settingType = getSettingType(this.viewType);

--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -525,12 +525,13 @@ export class ChatContainer extends Component {
 			let firstText = true;
 			for await (const message of stream) {
 				if (this._abortController?.signal.aborted) break;
+				const msg = message as any;
 				// Capture session ID from first message
-				if (!this.claudeCodeSessionId && (message as { session_id?: string }).session_id) {
-					this.claudeCodeSessionId = (message as { session_id?: string }).session_id ?? null;
+				if (!this.claudeCodeSessionId && msg.session_id) {
+					this.claudeCodeSessionId = msg.session_id ?? null;
 				}
-				if (message.type === "assistant") {
-					for (const block of message.message.content) {
+				if (msg.type === "assistant") {
+					for (const block of msg.message?.content ?? []) {
 						if (block.type === "text" && block.text) {
 							if (firstText) {
 								this.streamingDiv.empty();
@@ -539,13 +540,37 @@ export class ChatContainer extends Component {
 							this.previewText += block.text;
 							this.streamingDiv.textContent = this.previewText;
 							this.historyMessages.scroll(0, 9999);
+						} else if (block.type === "tool_use") {
+							// Show which tool Claude Code is running
+							const toolLabel = (block.name as string).replace(/_/g, " ");
+							this.showThinkingAnimation(`Running: ${toolLabel}`);
+							firstText = true; // next text chunk clears the animation
 						}
 					}
+				} else if (msg.type === "tool_use_summary") {
+					// After tool batch completes, resume "Thinking…"
+					this.showThinkingAnimation();
+					firstText = true;
+				} else if (msg.type === "result" && msg.usage) {
+					// Final result message — capture token usage
+					this.lastTokenUsage = {
+						inputTokens: msg.usage.input_tokens ?? 0,
+						outputTokens: msg.usage.output_tokens ?? 0,
+					};
 				}
 			}
 
 			this.streamingDiv.empty();
 			await this.renderMarkdown(this.previewText, this.streamingDiv);
+			// Append token usage before addMessage triggers a DOM re-render
+			if (this.lastTokenUsage) {
+				this.appendTokenUsage(
+					this.loadingDivContainer,
+					this.lastTokenUsage.inputTokens,
+					this.lastTokenUsage.outputTokens
+				);
+				this.lastTokenUsage = null;
+			}
 			this.messageStore.addMessage({
 				role: assistant,
 				content: this.previewText,
@@ -978,7 +1003,7 @@ export class ChatContainer extends Component {
 				if (contextFile) {
 					const content = await this.plugin.app.vault.read(contextFile);
 					const activeFileContextString =
-						`# Active File: ${contextFile.name}\nPath: \`${contextFile.path}\`\n\n\`\`\`\n${content}\n\`\`\`\n`;
+						`# User's Active Note (the note they are asking about)\nFile: ${contextFile.name}\nPath: \`${contextFile.path}\`\n\nThis note is already loaded below — do not use file-reading tools to re-read it.\n\n\`\`\`\n${content}\n\`\`\`\n`;
 					// Override any previously built context string — explicit toggle wins
 					this.pendingContextString = activeFileContextString;
 					this.currentVaultContext = {
@@ -1038,7 +1063,7 @@ export class ChatContainer extends Component {
 							} catch { continue; }
 						}
 						blocks.push(
-							`# Attached folder: ${entry.label} (${entry.absPath})\n\n## File listing\n\`\`\`\n${listing}\n\`\`\`\n\n## File contents\n\n` +
+							`# Attached folder: ${entry.label}\nPath: ${entry.absPath}\n\nThis folder's contents are pre-loaded below. Do NOT use file-reading or directory-listing tools to re-read these files — use the content already provided here to answer the user's question.\n\n## File listing\n\`\`\`\n${listing}\n\`\`\`\n\n## File contents\n\n` +
 							(fileBlocks.length > 0 ? fileBlocks.join("\n\n") : "(no readable text files found)")
 						);
 					} else {
@@ -1051,7 +1076,7 @@ export class ChatContainer extends Component {
 							nodeFs.closeSync(fd);
 							const ext = nodePath.extname(entry.absPath).replace(/^\./, "").toLowerCase();
 							const truncNote = read === MAX_FILE_BYTES && st.size > MAX_FILE_BYTES ? ` (truncated to first ${MAX_FILE_BYTES} bytes)` : "";
-							blocks.push(`# Attached file: ${entry.label} (${entry.absPath})${truncNote}\n\n\`\`\`${ext}\n${buf.subarray(0, read).toString("utf8")}\n\`\`\``);
+							blocks.push(`# Attached file: ${entry.label}\nPath: ${entry.absPath}${truncNote}\n\nThis file is pre-loaded below. Do NOT use file-reading tools to re-read it.\n\n\`\`\`${ext}\n${buf.subarray(0, read).toString("utf8")}\n\`\`\``);
 						} catch (e) {
 							blocks.push(`# Attached file: ${entry.label}\n\n(Error reading file: ${e})`);
 						}
@@ -1072,16 +1097,21 @@ export class ChatContainer extends Component {
 		// so the model knows which file to act on when the user says "this page", etc.
 		// Only inject when the user has active-file context enabled — otherwise agent
 		// models will autonomously read the file even though the user turned it off.
-		if (this.supportsAgentMode(modelType) && modelEndpoint !== images && this.useActiveFileContext) {
-			const activeFile = this.plugin.app.workspace.getActiveFile();
-			if (activeFile || this.pendingContextString) {
-				const activeHint = activeFile
-					? `The user's currently active note is "${activeFile.name}" at vault path "${activeFile.path}". When the user refers to "this page", "this note", "this file", or similar, they mean this file.\n\n`
-					: "";
-				if (activeHint && this.pendingContextString) {
-					this.pendingContextString = activeHint + this.pendingContextString;
-				} else if (activeHint && !this.pendingContextString) {
-					this.pendingContextString = activeHint;
+		if (this.supportsAgentMode(modelType) && modelEndpoint !== images) {
+			const activeFile = this.useActiveFileContext ? this.plugin.app.workspace.getActiveFile() : null;
+			const hasLocalPaths = this.localContextPaths.length > 0;
+			if (activeFile || hasLocalPaths || this.pendingContextString) {
+				const parts: string[] = [];
+				if (activeFile && this.useActiveFileContext) {
+					parts.push(`The user's currently active note is "${activeFile.name}" (vault path: "${activeFile.path}"). When the user refers to "this page", "this note", "this file", or similar, they mean this note. Its content is pre-loaded in the context below — do not use file-reading tools to re-read it.`);
+				}
+				if (hasLocalPaths) {
+					const labels = this.localContextPaths.map((p) => `"${p.label}" (${p.isDir ? "folder" : "file"}: ${p.absPath})`).join(", ");
+					parts.push(`The user has attached the following local ${this.localContextPaths.length === 1 ? "path" : "paths"} as context: ${labels}. Their contents are pre-loaded below — do NOT use file-reading or directory tools to re-read them. Use the pre-loaded content to answer the question directly.`);
+				}
+				if (parts.length > 0) {
+					const hint = parts.join("\n\n") + "\n\n";
+					this.pendingContextString = hint + (this.pendingContextString ?? "");
 				}
 			}
 		}
@@ -1977,6 +2007,14 @@ export class ChatContainer extends Component {
 				// onChunk will replace streamingDiv content with accumulated text.
 				this.showThinkingAnimation();
 			},
+			onToolStart: (toolName) => {
+				// Show which tool is currently running
+				const displayName = toolName.replace(/_/g, " ");
+				this.showThinkingAnimation(`Running: ${displayName}`);
+			},
+			onUsage: (inputTokens, outputTokens) => {
+				this.lastTokenUsage = { inputTokens, outputTokens };
+			},
 			onToolResult: (toolName, input, result) => {
 				// Track for RAG sources panel
 				if (toolName === "search_vault_semantic") {
@@ -2262,7 +2300,9 @@ export class ChatContainer extends Component {
 				this.allSkillsByTurn.size > 0 ? this.allSkillsByTurn : undefined,
 				undefined, // projectName — unchanged on update
 				undefined, // isAgent — unchanged on update
-				this.allModelsByTurn.size > 0 ? this.allModelsByTurn : undefined
+				this.allModelsByTurn.size > 0 ? this.allModelsByTurn : undefined,
+				undefined, // saveFolder — unchanged on update
+				this.localContextPaths.length > 0 ? this.localContextPaths : undefined
 			);
 			return;
 		}
@@ -2311,7 +2351,8 @@ export class ChatContainer extends Component {
 			activeProject?.name,
 			this.isObsidianAgent && this.plugin.settings.obsidianAgentSettings?.enabled,
 			this.allModelsByTurn.size > 0 ? this.allModelsByTurn : undefined,
-			saveFolder
+			saveFolder,
+			this.localContextPaths.length > 0 ? this.localContextPaths : undefined
 		);
 
 		this.currentHistoryFilePath = filePath;
@@ -2865,9 +2906,16 @@ export class ChatContainer extends Component {
 				const rect = (promptContainer as HTMLElement).getBoundingClientRect();
 				const menuH = slashMenu.offsetHeight;
 				const gap = 6;
+				const topAbove = rect.top - menuH - gap;
 				slashMenu.style.left = `${rect.left}px`;
-				slashMenu.style.top = `${rect.top - menuH - gap}px`;
-				slashMenu.style.bottom = "";
+				if (topAbove >= 0) {
+					slashMenu.style.top = `${topAbove}px`;
+					slashMenu.style.bottom = "";
+				} else {
+					// Not enough room above — position below the prompt container instead
+					slashMenu.style.top = `${rect.bottom + gap}px`;
+					slashMenu.style.bottom = "";
+				}
 			});
 		};
 
@@ -2994,7 +3042,7 @@ export class ChatContainer extends Component {
 					title: "Attach file or folder",
 					defaultPath: lastDir,
 					buttonLabel: "Attach",
-					properties: ["openFile", "openDirectory"],
+					properties: ["openFile", "openDirectory", "showHiddenFiles"],
 				}).then((result: { canceled: boolean; filePaths: string[] }) => {
 					if (result.canceled || result.filePaths.length === 0) return;
 					const absPath = result.filePaths[0];
@@ -3766,14 +3814,14 @@ export class ChatContainer extends Component {
 		});
 	}
 
-	showThinkingAnimation() {
+	showThinkingAnimation(label?: string) {
 		this.streamingDiv.empty();
 		const thinkingContainer = this.streamingDiv.createDiv({
 			cls: "llm-thinking-animation"
 		});
 		thinkingContainer.createSpan({
 			cls: "llm-thinking-text",
-			text: "Thinking"
+			text: label ?? "Thinking"
 		});
 		const dots = thinkingContainer.createSpan({ cls: "llm-thinking-dots" });
 		for (let i = 0; i < 3; i++) {

--- a/src/Plugin/Widget/Widget.ts
+++ b/src/Plugin/Widget/Widget.ts
@@ -116,6 +116,12 @@ export class WidgetView extends ItemView {
 			// the model/assistant used in this conversation (not the current default).
 			this.chatContainer.isObsidianAgent = !!meta.agent;
 
+			// Restore attached local paths (from /attach slash command)
+			if (meta.localPaths?.length) {
+				this.chatContainer.localContextPaths = meta.localPaths;
+				this.chatContainer.syncChips();
+			}
+
 			// Track the file path so subsequent sends update the right file
 			setHistoryFilePath(this.plugin, "widget", filePath);
 			this.chatContainer.currentHistoryFilePath = filePath;
@@ -261,6 +267,12 @@ export class WidgetView extends ItemView {
 		if (pendingFilePath) {
 			this.plugin.pendingWidgetFilePath = null;
 			await this.loadChatFile(pendingFilePath);
+		} else if (!pendingIndex || pendingIndex < 0) {
+			// Restore last open chat file from settings (persisted across reloads)
+			const lastFilePath = this.plugin.settings.widgetSettings.historyFilePath;
+			if (lastFilePath && this.plugin.app.vault.getFileByPath(lastFilePath)) {
+				await this.loadChatFile(lastFilePath);
+			}
 		}
 	}
 

--- a/src/Settings/LLMSettingsModal.ts
+++ b/src/Settings/LLMSettingsModal.ts
@@ -1167,7 +1167,7 @@ export class LLMSettingsModal extends Modal {
 
 		// Ensure toolSettings exists (deep-merge guard for existing installs)
 		if (!this.plugin.settings.toolSettings) {
-			this.plugin.settings.toolSettings = { disabledTools: [], maxToolCalls: 10 };
+			this.plugin.settings.toolSettings = { disabledTools: ["run_shell_command"], maxToolCalls: 10, shellCommandOptedIn: false };
 		}
 
 		// ── Agent behaviour ───────────────────────────────────────────────────
@@ -1258,6 +1258,21 @@ export class LLMSettingsModal extends Modal {
 			setting.addToggle((toggle) => {
 				toggle.setValue(!disabledTools.includes(tool.name));
 				toggle.onChange(async (enabled) => {
+					if (enabled && tool.requiresShellConfirm) {
+						// Revert the toggle immediately; only commit after user confirms
+						toggle.setValue(false);
+						new ShellCommandWarningModal(this.app, async () => {
+							this.plugin.settings.toolSettings.shellCommandOptedIn = true;
+							const idx = this.plugin.settings.toolSettings.disabledTools.indexOf(tool.name);
+							if (idx !== -1) this.plugin.settings.toolSettings.disabledTools.splice(idx, 1);
+							await this.plugin.saveSettings();
+							toggle.setValue(true);
+						}).open();
+						return;
+					}
+					if (!enabled && tool.requiresShellConfirm) {
+						this.plugin.settings.toolSettings.shellCommandOptedIn = false;
+					}
 					const idx = this.plugin.settings.toolSettings.disabledTools.indexOf(tool.name);
 					if (enabled && idx !== -1) {
 						this.plugin.settings.toolSettings.disabledTools.splice(idx, 1);
@@ -2516,5 +2531,42 @@ class GuidanceEditorOverlay {
 	close() {
 		this.overlayEl?.remove();
 		this.overlayEl = null;
+	}
+}
+
+class ShellCommandWarningModal extends Modal {
+	constructor(app: App, private onConfirm: () => void) {
+		super(app);
+	}
+
+	onOpen() {
+		const { contentEl } = this;
+		contentEl.createEl("h2", { text: "⚠ Enable Shell Command Tool?" });
+		contentEl.createEl("p", {
+			text: "The run_shell_command tool lets the AI execute arbitrary shell commands on your computer — it can read, write, or delete any file and run any program.",
+		});
+		contentEl.createEl("p", {
+			text: "Only enable this if you understand the risks and trust the prompts you send to the agent. A rogue or poorly-worded prompt could cause irreversible damage.",
+		});
+		contentEl.createEl("p", {
+			cls: "llm-shell-warning-note",
+			text: "Tip: use it for read-only tasks like 'git log' or 'grep' — avoid prompts that ask the agent to write or delete files via the shell.",
+		});
+
+		const btnRow = contentEl.createDiv({ cls: "llm-shell-warning-buttons" });
+		new ButtonComponent(btnRow)
+			.setButtonText("Cancel")
+			.onClick(() => this.close());
+		new ButtonComponent(btnRow)
+			.setButtonText("Yes, enable shell commands")
+			.setWarning()
+			.onClick(() => {
+				this.close();
+				this.onConfirm();
+			});
+	}
+
+	onClose() {
+		this.contentEl.empty();
 	}
 }

--- a/src/Settings/LLMSettingsModal.ts
+++ b/src/Settings/LLMSettingsModal.ts
@@ -5,6 +5,7 @@ import {
 	DropdownComponent,
 	Modal,
 	Notice,
+	requestUrl,
 	Setting,
 	setIcon,
 	TFile,
@@ -825,9 +826,47 @@ export class LLMSettingsModal extends Modal {
 		const apiItems = this.addSettingGroup(el);
 		this.renderApiKeyField(apiItems, this.apiKeyConfigs.claude);
 
+		// Test Claude API key button + status
+		const apiTestSetting = new Setting(apiItems)
+			.setName("Test Claude API key")
+			.setDesc("Verify your API key is valid and can reach the Anthropic API.");
+		let apiStatusEl: HTMLElement | null = null;
+		apiTestSetting.addButton((btn) => {
+			btn.setButtonText("Test");
+			btn.onClick(async () => {
+				if (apiStatusEl) apiStatusEl.remove();
+				apiStatusEl = apiTestSetting.descEl.createDiv({ cls: "llm-api-test-status llm-api-test-running", text: "Testing…" });
+				btn.setDisabled(true);
+				try {
+					const key = this.plugin.settings.claudeAPIKey?.trim();
+					if (!key) throw new Error("No API key configured.");
+					const resp = await requestUrl({
+						url: "https://api.anthropic.com/v1/models",
+						headers: { "x-api-key": key, "anthropic-version": "2023-06-01" },
+						throw: false,
+					});
+					if (resp.status < 400) {
+						apiStatusEl.className = "llm-api-test-status llm-api-test-ok";
+						apiStatusEl.setText("✓ API key is valid.");
+					} else {
+						const msg = resp.json?.error?.message ?? resp.text ?? String(resp.status);
+						apiStatusEl.className = "llm-api-test-status llm-api-test-fail";
+						apiStatusEl.setText(`✗ ${resp.status}: ${msg}`);
+					}
+				} catch (e: any) {
+					if (apiStatusEl) {
+						apiStatusEl.className = "llm-api-test-status llm-api-test-fail";
+						apiStatusEl.setText(`✗ ${e.message ?? "Unknown error"}`);
+					}
+				} finally {
+					btn.setDisabled(false);
+				}
+			});
+		});
+
 		// Claude Code
 		const authItems = this.addSettingGroup(el, "Claude Code");
-		new Setting(authItems)
+		const oauthSetting = new Setting(authItems)
 			.setName("Claude Code OAuth token")
 			.setDesc("OAuth token for authenticating with Claude Code (CLAUDE_CODE_OAUTH_TOKEN).")
 			.addText((text) => {
@@ -837,8 +876,64 @@ export class LLMSettingsModal extends Modal {
 					this.plugin.settings.claudeCodeOAuthToken = value;
 					void this.plugin.saveSettings();
 				});
+			})
+			.addButton((btn) => {
+				btn.setButtonText("Sync from Keychain").setTooltip("Read token from macOS Keychain (requires Claude Code desktop app to be installed and authenticated)");
+				btn.onClick(async () => {
+					btn.setDisabled(true);
+					btn.setButtonText("Syncing…");
+					const token = await this.plugin.readClaudeCodeTokenFromKeychain();
+					btn.setDisabled(false);
+					btn.setButtonText("Sync from Keychain");
+					if (token) {
+						this.plugin.settings.claudeCodeOAuthToken = token;
+						await this.plugin.saveSettings();
+						// Re-render to show updated value in the password field
+						this.renderTab("anthropic");
+						new Notice("✓ Claude Code token synced from Keychain.");
+					} else {
+						new Notice("Could not read token from Keychain. Make sure Claude Code is installed and you've run `claude` to authenticate.", 8000);
+					}
+				});
 			});
 
+		// Test OAuth token button + status
+		const oauthTestSetting = new Setting(authItems)
+			.setName("Test OAuth token")
+			.setDesc("Verify your Claude Code OAuth token is valid.");
+		let oauthStatusEl: HTMLElement | null = null;
+		oauthTestSetting.addButton((btn) => {
+			btn.setButtonText("Test");
+			btn.onClick(async () => {
+				if (oauthStatusEl) oauthStatusEl.remove();
+				oauthStatusEl = oauthTestSetting.descEl.createDiv({ cls: "llm-api-test-status llm-api-test-running", text: "Testing…" });
+				btn.setDisabled(true);
+				try {
+					const token = this.plugin.settings.claudeCodeOAuthToken?.trim();
+					if (!token) throw new Error("No OAuth token configured.");
+					const resp = await requestUrl({
+						url: "https://api.anthropic.com/v1/models",
+						headers: { "Authorization": `Bearer ${token}`, "anthropic-version": "2023-06-01" },
+						throw: false,
+					});
+					if (resp.status < 400) {
+						oauthStatusEl.className = "llm-api-test-status llm-api-test-ok";
+						oauthStatusEl.setText("✓ OAuth token is valid.");
+					} else {
+						const msg = resp.json?.error?.message ?? resp.text ?? String(resp.status);
+						oauthStatusEl.className = "llm-api-test-status llm-api-test-fail";
+						oauthStatusEl.setText(`✗ ${resp.status}: ${msg}`);
+					}
+				} catch (e: any) {
+					if (oauthStatusEl) {
+						oauthStatusEl.className = "llm-api-test-status llm-api-test-fail";
+						oauthStatusEl.setText(`✗ ${e.message ?? "Unknown error"}`);
+					}
+				} finally {
+					btn.setDisabled(false);
+				}
+			});
+		});
 	}
 
 	private renderConnectors() {

--- a/src/Types/types.ts
+++ b/src/Types/types.ts
@@ -286,6 +286,12 @@ export type ToolSettings = {
 	 * is forced to stop. Prevents runaway agents.
 	 */
 	maxToolCalls: number;
+	/**
+	 * Explicit opt-in for run_shell_command. Must be true before the tool can be
+	 * removed from disabledTools. Defaults to false so the tool is always off
+	 * unless the user consciously enables it via the warning dialog in Settings.
+	 */
+	shellCommandOptedIn: boolean;
 };
 
 export type RAGSettings = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -239,8 +239,9 @@ export const DEFAULT_SETTINGS: LLMPluginSettings = {
 		activeAssistantId: null,
 	},
 	toolSettings: {
-		disabledTools: [],
+		disabledTools: ["run_shell_command"],
 		maxToolCalls: 10,
+		shellCommandOptedIn: false,
 	},
 	obsidianAgentSettings: {
 		enabled: false,
@@ -1366,6 +1367,14 @@ export default class LLMPlugin extends Plugin {
 				...DEFAULT_SETTINGS.toolSettings,
 				...(dataJSON.toolSettings ?? {}),
 			};
+			// run_shell_command requires explicit opt-in. On upgrades from versions that
+			// predate this tool, the saved disabledTools won't include it — force it disabled
+			// unless the user has explicitly opted in via the Settings warning dialog.
+			if (!this.settings.toolSettings.shellCommandOptedIn) {
+				if (!this.settings.toolSettings.disabledTools.includes("run_shell_command")) {
+					this.settings.toolSettings.disabledTools.push("run_shell_command");
+				}
+			}
 
 			// Deep-merge obsidianAgentSettings — nested Records need spread so new keys get defaults
 			this.settings.obsidianAgentSettings = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -351,6 +351,15 @@ export default class LLMPlugin extends Plugin {
 			: new MobileOperatingSystem();
 		await this.loadSettings();
 
+		// Auto-populate the Claude Code OAuth token from the macOS Keychain if not set.
+		if (!this.settings.claudeCodeOAuthToken) {
+			const token = await this.readClaudeCodeTokenFromKeychain();
+			if (token) {
+				this.settings.claudeCodeOAuthToken = token;
+				await this.saveSettings();
+			}
+		}
+
 		// Show a one-time welcome Notice on first load (new installs and upgraders alike).
 		if (!this.settings.hasOnboarded) {
 			new Notice(
@@ -1417,6 +1426,32 @@ export default class LLMPlugin extends Plugin {
 
 	async saveSettings() {
 		await this.saveData(this.settings);
+	}
+
+	/**
+	 * Reads the Claude Code OAuth access token from the macOS Keychain.
+	 * Returns the token string on success, or null if unavailable/unsupported.
+	 * Also checks expiry — returns null (and logs a warning) if the token is expired.
+	 */
+	async readClaudeCodeTokenFromKeychain(): Promise<string | null> {
+		if (typeof process === "undefined" || process.platform !== "darwin") return null;
+		try {
+			const { execSync } = require("child_process") as typeof import("child_process");
+			const raw = execSync(
+				`security find-generic-password -s "Claude Code-credentials" -w`,
+				{ timeout: 5000, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }
+			).trim();
+			const data = JSON.parse(raw);
+			const oauth = data?.claudeAiOauth;
+			if (!oauth?.accessToken) return null;
+			if (oauth.expiresAt && Date.now() > oauth.expiresAt) {
+				console.warn("[LLM Plugin] Claude Code OAuth token is expired. Re-authenticate via `claude` in your terminal.");
+				return null;
+			}
+			return oauth.accessToken as string;
+		} catch {
+			return null;
+		}
 	}
 
 	async validateActiveModelsAPIKeys() {

--- a/src/services/AgentLoop.ts
+++ b/src/services/AgentLoop.ts
@@ -31,8 +31,12 @@ export interface AgentCallbacks {
 	onChunk: (text: string) => void;
 	/** Called between tool execution and the next API request — re-show thinking. */
 	onThinking: () => void;
+	/** Optional — called just before a tool executes so the UI can show which tool is running. */
+	onToolStart?: (toolName: string, input: Record<string, any>) => void;
 	/** Optional — called after each successful tool execution with the tool name, input, and result text. */
 	onToolResult?: (toolName: string, input: Record<string, any>, result: string) => void;
+	/** Optional — called with cumulative token counts after each model turn. */
+	onUsage?: (inputTokens: number, outputTokens: number) => void;
 }
 
 export class AgentLoop {
@@ -125,6 +129,8 @@ export class AgentLoop {
 		let firstCall = true;
 		const toolSummaries: string[] = [];
 		let toolCallCount = 0;
+		let totalInputTokens = 0;
+		let totalOutputTokens = 0;
 
 		while (true) {
 			if (signal?.aborted) break;
@@ -176,8 +182,18 @@ export class AgentLoop {
 					}
 				} else if (event.type === "message_delta") {
 					stopReason = event.delta.stop_reason ?? null;
+					if ((event as any).usage) {
+						totalOutputTokens += (event as any).usage.output_tokens ?? 0;
+					}
+				} else if (event.type === "message_start") {
+					if ((event as any).message?.usage) {
+						totalInputTokens += (event as any).message.usage.input_tokens ?? 0;
+						totalOutputTokens += (event as any).message.usage.output_tokens ?? 0;
+					}
 				}
 			}
+
+			callbacks.onUsage?.(totalInputTokens, totalOutputTokens);
 
 			// Build typed content array for the assistant turn
 			const assistantContent: Anthropic.ContentBlockParam[] = [];
@@ -213,6 +229,7 @@ export class AgentLoop {
 				let input: Record<string, any> = {};
 				try { input = JSON.parse(block.inputJson || "{}"); } catch { /* ignore */ }
 
+				callbacks.onToolStart?.(block.name, input);
 				const allowed = await this.checkPermission(block.name, input);
 				let resultText: string;
 				if (allowed) {

--- a/src/services/ChatHistory.ts
+++ b/src/services/ChatHistory.ts
@@ -15,6 +15,8 @@ export interface ChatFileMeta {
 	project?: string;
 	/** True when this conversation was conducted through the Obsidian Agent. */
 	agent?: boolean;
+	/** Local filesystem paths attached via /attach slash command. */
+	localPaths?: { label: string; absPath: string; isDir: boolean }[];
 }
 
 export interface LoadedChat {
@@ -169,6 +171,14 @@ export class ChatHistory {
 			lines.push("context:");
 			for (const link of meta.context) {
 				lines.push(`  - "${link}"`);
+			}
+		}
+		if (meta.localPaths?.length) {
+			lines.push("localPaths:");
+			for (const p of meta.localPaths) {
+				lines.push(`  - label: "${p.label.replace(/"/g, '\\"')}"`);
+				lines.push(`    absPath: "${p.absPath.replace(/"/g, '\\"')}"`);
+				lines.push(`    isDir: ${p.isDir}`);
 			}
 		}
 		return lines.join("\n");
@@ -331,7 +341,8 @@ export class ChatHistory {
 		isAgent?: boolean,
 		modelsByTurn?: Map<number, string>,
 		/** Override the folder for new file creation (e.g. a project's chats folder). */
-		saveFolder?: string
+		saveFolder?: string,
+		localPaths?: { label: string; absPath: string; isDir: boolean }[]
 	): Promise<string> {
 		const targetFolder = saveFolder ?? this.folder;
 		await this.ensureFolderPath(targetFolder);
@@ -351,6 +362,7 @@ export class ChatHistory {
 				...existing.meta,
 				updated: now,
 				...(contextLinks.length ? { context: contextLinks } : {}),
+				...(localPaths?.length ? { localPaths } : {}),
 			};
 			await this.plugin.app.vault.modify(
 				file,
@@ -372,6 +384,7 @@ export class ChatHistory {
 				...(projectName ? { project: projectName } : {}),
 				...(isAgent ? { agent: true } : {}),
 				...(contextLinks.length ? { context: contextLinks } : {}),
+				...(localPaths?.length ? { localPaths } : {}),
 			};
 			await this.plugin.app.vault.create(
 				newPath,

--- a/src/services/ObsidianToolRegistry.ts
+++ b/src/services/ObsidianToolRegistry.ts
@@ -1,4 +1,7 @@
 import { App, TFile } from "obsidian";
+import * as fs from "fs";
+import * as path from "path";
+import * as child_process from "child_process";
 import { RiskTier } from "Types/types";
 import { VaultIndexer } from "RAG/VaultIndexer";
 import { ChatHistory } from "services/ChatHistory";
@@ -19,6 +22,12 @@ export interface NeutralToolDefinition {
 	requiresRag?: boolean;
 	/** When true, a note is shown in Settings that this tool requires SearXNG to be configured. */
 	requiresWebSearch?: boolean;
+	/**
+	 * When true, enabling this tool in Settings shows a security warning and requires
+	 * the user to explicitly confirm. The tool also defaults to disabled and requires
+	 * shellCommandOptedIn to be set before it can be active.
+	 */
+	requiresShellConfirm?: boolean;
 }
 
 export type ToolResult = { success: boolean; result?: string; error?: string };
@@ -221,6 +230,52 @@ export const ALL_TOOL_DEFINITIONS: NeutralToolDefinition[] = [
 		},
 		risk: "safe",
 		requiresWebSearch: true,
+	},
+	{
+		name: "read_local_file",
+		displayName: "Read local file",
+		description: "Read the contents of any file on the local filesystem by its absolute path. Use this to inspect source code, config files, or any text file outside the vault — for example, another plugin you are developing.",
+		parameters: {
+			type: "object",
+			properties: {
+				file_path: { type: "string", description: "Absolute path to the file (e.g. '/Users/you/projects/my-plugin/src/main.ts')." },
+				max_bytes: { type: "string", description: "Maximum number of bytes to read from the start of the file (default 200000, max 500000). Useful for large files." },
+			},
+			required: ["file_path"],
+		},
+		risk: "safe",
+	},
+	{
+		name: "list_local_folder",
+		displayName: "List local folder",
+		description: "List files and subdirectories in any folder on the local filesystem. Optionally recurse into subdirectories and filter by file extension.",
+		parameters: {
+			type: "object",
+			properties: {
+				folder_path: { type: "string", description: "Absolute path to the folder to list (e.g. '/Users/you/projects/my-plugin/src')." },
+				recursive: { type: "string", description: "'true' to recurse into subdirectories (default 'false')." },
+				extension: { type: "string", description: "Optional file extension filter without leading dot (e.g. 'ts', 'md'). Only files with this extension are returned." },
+				max_entries: { type: "string", description: "Maximum number of entries to return (1–500, default 200)." },
+			},
+			required: ["folder_path"],
+		},
+		risk: "safe",
+	},
+	{
+		name: "run_shell_command",
+		displayName: "Run shell command",
+		description: "Execute an arbitrary shell command and return its stdout/stderr output. CAUTION: this tool can read, write, or delete any file on your system and run any program. Only enable it if you understand the risks and trust the prompts you send to the agent.",
+		parameters: {
+			type: "object",
+			properties: {
+				command: { type: "string", description: "The shell command to run (executed via /bin/sh -c on macOS/Linux, cmd /c on Windows)." },
+				cwd: { type: "string", description: "Optional working directory for the command (absolute path). Defaults to the vault base path." },
+				timeout_ms: { type: "string", description: "Timeout in milliseconds before the command is killed (default 15000, max 60000)." },
+			},
+			required: ["command"],
+		},
+		risk: "danger",
+		requiresShellConfirm: true,
 	},
 	{
 		name: "get_chat_history",
@@ -607,6 +662,110 @@ export class ObsidianToolRegistry {
 					}
 
 					return { success: false, error: `Unknown action: ${action}. Use 'list' or 'load'.` };
+				}
+
+				case "read_local_file": {
+					const { file_path: filePath, max_bytes: maxBytesArg } = input as { file_path: string; max_bytes?: string };
+					const maxBytes = Math.min(500000, Math.max(1, parseInt(maxBytesArg ?? "200000", 10) || 200000));
+					if (!path.isAbsolute(filePath)) {
+						return { success: false, error: `file_path must be an absolute path. Got: ${filePath}` };
+					}
+					if (!fs.existsSync(filePath)) {
+						return { success: false, error: `File not found: ${filePath}` };
+					}
+					const stat = fs.statSync(filePath);
+					if (stat.isDirectory()) {
+						return { success: false, error: `Path is a directory. Use list_local_folder to list its contents.` };
+					}
+					const fd = fs.openSync(filePath, "r");
+					const buf = Buffer.alloc(maxBytes);
+					const bytesRead = fs.readSync(fd, buf, 0, maxBytes, 0);
+					fs.closeSync(fd);
+					const content = buf.subarray(0, bytesRead).toString("utf8");
+					const truncated = bytesRead === maxBytes && stat.size > maxBytes;
+					const header = `File: ${filePath} (${stat.size} bytes${truncated ? `, showing first ${maxBytes}` : ""}):\n\n`;
+					return { success: true, result: header + content };
+				}
+
+				case "list_local_folder": {
+					const {
+						folder_path: folderPath,
+						recursive: recursiveArg,
+						extension,
+						max_entries: maxEntriesArg,
+					} = input as { folder_path: string; recursive?: string; extension?: string; max_entries?: string };
+
+					if (!path.isAbsolute(folderPath)) {
+						return { success: false, error: `folder_path must be an absolute path. Got: ${folderPath}` };
+					}
+					if (!fs.existsSync(folderPath)) {
+						return { success: false, error: `Folder not found: ${folderPath}` };
+					}
+					const stat = fs.statSync(folderPath);
+					if (!stat.isDirectory()) {
+						return { success: false, error: `Path is not a directory. Use read_local_file to read a file.` };
+					}
+
+					const recursive = recursiveArg === "true";
+					const maxEntries = Math.min(500, Math.max(1, parseInt(maxEntriesArg ?? "200", 10) || 200));
+					const extFilter = extension ? extension.replace(/^\./, "").toLowerCase() : null;
+
+					const entries: string[] = [];
+					const walk = (dir: string) => {
+						if (entries.length >= maxEntries) return;
+						let items: string[];
+						try { items = fs.readdirSync(dir); } catch { return; }
+						for (const item of items) {
+							if (entries.length >= maxEntries) break;
+							const full = path.join(dir, item);
+							let itemStat: fs.Stats;
+							try { itemStat = fs.statSync(full); } catch { continue; }
+							if (itemStat.isDirectory()) {
+								entries.push(full + "/");
+								if (recursive) walk(full);
+							} else {
+								if (!extFilter || path.extname(item).replace(/^\./, "").toLowerCase() === extFilter) {
+									entries.push(full);
+								}
+							}
+						}
+					};
+					walk(folderPath);
+
+					if (entries.length === 0) {
+						return { success: true, result: `No entries found in ${folderPath}${extFilter ? ` (filter: .${extFilter})` : ""}.` };
+					}
+					const truncated = entries.length >= maxEntries;
+					const header = `${entries.length} entr${entries.length === 1 ? "y" : "ies"} in ${folderPath}${truncated ? " (truncated)" : ""}:\n\n`;
+					return { success: true, result: header + entries.join("\n") };
+				}
+
+				case "run_shell_command": {
+					const { command, cwd: cwdArg, timeout_ms: timeoutArg } = input as { command: string; cwd?: string; timeout_ms?: string };
+					const timeoutMs = Math.min(60000, Math.max(1000, parseInt(timeoutArg ?? "15000", 10) || 15000));
+					const cwd = cwdArg ?? (this.app.vault.adapter as any).basePath ?? process.cwd();
+
+					return new Promise<ToolResult>((resolve) => {
+						child_process.exec(
+							command,
+							{ cwd, timeout: timeoutMs, maxBuffer: 2 * 1024 * 1024 },
+							(err, stdout, stderr) => {
+								const out = [
+									stdout ? `stdout:\n${stdout}` : "",
+									stderr ? `stderr:\n${stderr}` : "",
+								].filter(Boolean).join("\n\n");
+								if (err && !stdout && !stderr) {
+									resolve({ success: false, error: `Command failed (exit ${err.code ?? "?"}): ${err.message}` });
+								} else {
+									resolve({
+										success: !err || !!stdout,
+										result: out || "(no output)",
+										...(err ? { error: `Exited with code ${err.code ?? "?"}` } : {}),
+									});
+								}
+							}
+						);
+					});
 				}
 
 				default:

--- a/styles.css
+++ b/styles.css
@@ -315,14 +315,16 @@ button.llm-send-button:disabled {
 
 /* Stop mode — shown while the model is generating */
 button.llm-send-button.llm-stop-mode {
-	background-color: var(--color-red);
-	color: white;
+	background-color: var(--background-primary);
+	color: var(--text-muted);
+	border: var(--border-width) solid var(--background-modifier-border);
 }
 
 button.llm-send-button.llm-stop-mode:hover {
-	background-color: var(--color-red);
-	opacity: 0.8;
-	color: white;
+	background-color: var(--background-modifier-hover);
+	color: var(--text-normal);
+	border-color: var(--background-modifier-border-hover);
+	opacity: 1;
 }
 
 .llm-modal-send-button,
@@ -2038,6 +2040,18 @@ details[open] .llm-tool-calls-chevron {
 	gap: var(--size-4-2);
 	margin-top: var(--size-4-4);
 }
+
+/* ── API key test status ──────────────────────────────────────────────────── */
+
+.llm-api-test-status {
+	margin-top: var(--size-4-1);
+	font-size: var(--font-ui-smaller);
+	font-weight: var(--font-medium);
+}
+
+.llm-api-test-running { color: var(--text-muted); }
+.llm-api-test-ok      { color: var(--color-green); }
+.llm-api-test-fail    { color: var(--color-red); }
 
 /* ── Active skill indicator (shown above an assistant message) ────────────── */
 

--- a/styles.css
+++ b/styles.css
@@ -2022,6 +2022,23 @@ details[open] .llm-tool-calls-chevron {
 	color: var(--text-faint);
 }
 
+/* ── Shell command warning modal ─────────────────────────────────────────── */
+
+.llm-shell-warning-note {
+	font-size: var(--font-ui-small);
+	color: var(--text-muted);
+	padding: var(--size-4-2) var(--size-4-3);
+	border-left: 3px solid var(--color-orange);
+	margin-top: var(--size-4-2);
+}
+
+.llm-shell-warning-buttons {
+	display: flex;
+	justify-content: flex-end;
+	gap: var(--size-4-2);
+	margin-top: var(--size-4-4);
+}
+
 /* ── Active skill indicator (shown above an assistant message) ────────────── */
 
 .llm-skill-panel {


### PR DESCRIPTION
## Summary

- **Local filesystem tools** — `read_local_file`, `list_local_folder`, and `run_shell_command` (off by default, requires explicit opt-in with warning dialog) added to `ObsidianToolRegistry`
- **`/attach` slash command** — type `/` in the chat input to open a native OS file/folder picker (supports both); selected path appears as a chip in the chip strip and is pre-loaded as context at send time; paths persist to chat frontmatter and restore on reopen
- **Slash menu fix** — menu now positions below the prompt when there isn't room above (e.g. compact modal near top of screen)
- **`showHiddenFiles`** added to the `/attach` file picker so dotfiles are always visible
- **API key validation** — "Test" buttons for Claude API key and OAuth token in Anthropic settings hit `/v1/models` via `requestUrl` and show inline ✓/✗ status
- **macOS Keychain sync** — `readClaudeCodeTokenFromKeychain()` reads the `claudeAiOauth` access token from the `Claude Code-credentials` keychain entry; auto-populates on plugin load if empty; "Sync from Keychain" button for manual refresh
- **Thinking animation** — shows "Running: \<tool name\>" during tool execution for both the AgentLoop and Claude Code SDK paths
- **Token usage display** — token counts now shown after Obsidian Agent (Claude Code) responses, accumulated across all tool-call turns; fix for DOM timing so the panel renders before `messageStore.addMessage` triggers re-render
- **Context framing** — attached vault notes and local paths labeled as pre-loaded in the injected context so the agent doesn't try to re-read them with tools; agent hint explicitly lists all attached paths
- **Stop button styling** — changed from red to subtle white/grey using core Obsidian variables, matching the add-context button
- **Widget chat restore** — widget now reloads the last open chat file on plugin reload using the already-persisted `historyFilePath` in `widgetSettings`

## Test plan

- [ ] Type `/` in chat input → slash menu appears; type `att` → "Attach local file or folder" shown; press Enter → OS picker opens with hidden files visible
- [ ] Pick a file → chip appears; pick a folder → folder chip appears; send a message → context injected; reopen chat → chips restored
- [ ] Settings → Anthropic → click "Test" on API key and OAuth token → shows ✓ or ✗ with error message
- [ ] Settings → Anthropic → click "Sync from Keychain" → token populates (macOS only)
- [ ] Settings → Tools → toggle `run_shell_command` on → warning modal appears; cancel → stays off; confirm → enables
- [ ] Obsidian Agent response shows "Running: \<tool\>" during tool calls and token count below response
- [ ] Stop button appears white/grey (not red) during generation
- [ ] Close and reopen Obsidian → widget reopens last chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)