### PR TITLE
feat: surface Claude Code permission requests inline in chat

### DIFF
--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -519,7 +519,8 @@ export class ChatContainer extends Component {
 				this.plugin.settings.linearWorkspaces,
 				vaultPath,
 				pluginDir,
-				this.claudeCodeSessionId ?? undefined
+				this.claudeCodeSessionId ?? undefined,
+				this.claudeCodeCanUseTool.bind(this)
 			);
 
 			let firstText = true;
@@ -550,6 +551,15 @@ export class ChatContainer extends Component {
 				} else if (msg.type === "tool_use_summary") {
 					// After tool batch completes, resume "Thinking…"
 					this.showThinkingAnimation();
+					firstText = true;
+				} else if (msg.type === "system" && msg.subtype === "permission_denied") {
+					// Auto-denied tool (e.g. classifier block, dontAsk mode) — surface inline
+					const toolLabel = (msg.tool_name as string).replace(/_/g, " ");
+					const notice = this.historyMessages.createDiv({ cls: "llm-permission-denied-notice" });
+					notice.createSpan({ cls: "llm-permission-denied-icon" });
+					setIcon(notice.querySelector(".llm-permission-denied-icon") as HTMLElement, "shield-x");
+					notice.createSpan({ text: `Action blocked: ${toolLabel}`, cls: "llm-permission-denied-text" });
+					this.historyMessages.scroll(0, 9999);
 					firstText = true;
 				} else if (msg.type === "result" && msg.usage) {
 					// Final result message — capture token usage
@@ -1722,10 +1732,20 @@ export class ChatContainer extends Component {
 		});
 	}
 
-	/**
-	 * Render an inline approval card in the chat history and return a Promise
-	 * that resolves to true (Allow) or false (Deny) when the user clicks.
-	 */
+	private async claudeCodeCanUseTool(
+		toolName: string,
+		input: Record<string, unknown>,
+		options: { title?: string; displayName?: string; description?: string; toolUseID: string }
+	): Promise<import("@anthropic-ai/claude-agent-sdk").PermissionResult> {
+		const label = options.title ?? `Claude wants to use: ${toolName.replace(/_/g, " ")}`;
+		const desc = options.description ?? options.displayName ?? "";
+		const allowed = await this.showPermissionUI(toolName, label + (desc ? `\n${desc}` : ""), input as Record<string, any>);
+		if (allowed) {
+			return { behavior: "allow", updatedInput: input };
+		}
+		return { behavior: "deny", message: "Action denied by user." };
+	}
+
 	private showPermissionUI(
 		toolName: string,
 		toolDescription: string,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -11,7 +11,7 @@ import {
 	gemini2FlashStableModel,
 	images,
 } from "utils/constants";
-import { query as claudeCodeQuery } from "@anthropic-ai/claude-agent-sdk";
+import { query as claudeCodeQuery, CanUseTool } from "@anthropic-ai/claude-agent-sdk";
 import { ensureSDKInstalled, getNativeBinaryPath } from "services/ClaudeAgentSDKInstaller";
 
 // Patch events.setMaxListeners for Electron compatibility.
@@ -303,7 +303,8 @@ export async function claudeCodeMessage(
 	linearWorkspaces: Array<{ name: string; apiKey: string }>,
 	cwd: string,
 	pluginDir: string,
-	sessionId?: string
+	sessionId?: string,
+	canUseTool?: CanUseTool
 ) {
 	if (!Platform.isDesktop) throw new Error("Claude Code is only available on desktop.");
 	await ensureSDKInstalled(pluginDir);
@@ -343,7 +344,8 @@ export async function claudeCodeMessage(
 			...(Object.keys(mcpServers).length > 0
 				? { mcpServers, allowedTools }
 				: {}),
-			permissionMode: "acceptEdits",
+			permissionMode: "default",
+			...(canUseTool ? { canUseTool } : {}),
 			cwd,
 			env: {
 				...process.env,

--- a/styles.css
+++ b/styles.css
@@ -1478,6 +1478,32 @@ button.llm-permission-allow {
 	padding: var(--size-4-1) var(--size-4-3);
 }
 
+/* PERMISSION DENIED NOTICE (Claude Code auto-block) */
+
+.llm-permission-denied-notice {
+	display: flex;
+	align-items: center;
+	gap: var(--size-4-2);
+	padding: var(--size-4-2) var(--size-4-3);
+	border-radius: var(--radius-s);
+	background-color: var(--background-modifier-error-hover);
+	border: var(--border-width) solid var(--background-modifier-error);
+	color: var(--text-error);
+	font-size: var(--font-ui-small);
+	margin: var(--size-4-2) 0;
+}
+
+.llm-permission-denied-icon {
+	display: flex;
+	align-items: center;
+	flex-shrink: 0;
+}
+
+.llm-permission-denied-icon svg {
+	width: var(--icon-s);
+	height: var(--icon-s);
+}
+
 /* MEMORY SCOPE PICKER (extends permission card) */
 
 .llm-memory-content-preview {


### PR DESCRIPTION
## Summary

- Routes Claude Code tool permission prompts through the plugin's existing permission card UI (`showPermissionUI`) instead of telling users to edit `~/.claude/settings.json` or use the terminal
- Changed `permissionMode` from `"acceptEdits"` to `"default"` so the SDK invokes the `canUseTool` callback for anything needing approval
- Added `claudeCodeCanUseTool` method on `ChatContainer` that bridges the SDK callback to the existing allow/deny card
- Auto-denied tools (classifier blocks, dontAsk mode) surface as an inline red notice with a shield icon

## Test plan

- [ ] Start a Claude Code conversation, ask it to perform an action that requires permission (e.g. web search, file outside vault)
- [ ] Confirm a permission card appears inline in the chat with Allow/Deny buttons
- [ ] Clicking Allow lets the tool proceed; clicking Deny returns "Action denied by user." to the model
- [ ] Auto-denied tools (if any) show the red inline notice instead of silently failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)