### PR TITLE
fix: Skills settings panel blank (timing race + missing empty states)

### DIFF
--- a/src/Settings/LLMSettingsModal.ts
+++ b/src/Settings/LLMSettingsModal.ts
@@ -1573,14 +1573,41 @@ export class LLMSettingsModal extends Modal {
 
 	private renderSkills() {
 		const el = this.mainContentEl;
-
 		const skillsFolder = this.plugin.skillsFolder;
 
-		if (!skillsFolder) return;
+		if (!skillsFolder) {
+			el.createEl("p", {
+				cls: "pane-empty",
+				text: "Set a Root Vault Folder in General settings to enable skills.",
+			});
+			return;
+		}
 
-		// Show the skills discovered in the current folder
 		const skills = this.plugin.skillRegistry?.getSkills() ?? [];
-		if (skills.length === 0) return;
+
+		if (skills.length === 0) {
+			el.createEl("p", {
+				cls: "pane-empty",
+				text: `No skills found in ${skillsFolder}. Add subfolders containing a SKILL.md file.`,
+			});
+			// Registry may not have loaded yet (onLayoutReady race). Reload once and
+			// re-render only if skills are actually found, to avoid a flash loop.
+			this.plugin.skillRegistry?.reloadAll().then(() => {
+				if (
+					this.activeTab === "skills" &&
+					(this.plugin.skillRegistry?.getSkills().length ?? 0) > 0
+				) {
+					this.renderTab("skills");
+				}
+			});
+			return;
+		}
+
+		new Setting(el).setName("Skills").setHeading();
+		new Setting(el).setDesc(
+			`Enable or disable skills globally. Skills are invoked with / in the chat input or via the + menu. ` +
+			`Skill files live in ${skillsFolder}.`
+		);
 
 		for (const skill of skills) {
 			new Setting(el)


### PR DESCRIPTION
## Summary

- `renderSkills()` returned silently with no content when the skill registry was empty — either because `onLayoutReady` hadn't finished yet (timing race) or because no root vault folder was set
- No heading or empty-state message existed, so the panel appeared completely blank in all empty cases
- Added descriptive `pane-empty` messages for both paths
- When the registry is empty but a skills folder is configured, a background `reloadAll()` is triggered; the panel re-renders once skills are found (resolves the timing race without a flash loop, since re-render is gated on `length > 0`)
- Added a "Skills" heading and description line when skills are present
- Same root cause explains why the `/`-slash menu showed nothing: if the registry was empty at chat-open time, skills weren't available to the menu

## Test plan

- [ ] Open settings immediately after Obsidian starts → Skills tab should show skills (or briefly show "No skills found" then auto-populate)
- [ ] Open settings with no root vault folder set → Skills tab shows "Set a Root Vault Folder…" message instead of blank
- [ ] Open settings after vault is fully loaded → Skills tab shows heading + toggles for each skill
- [ ] Type `/` in chat input → slash menu shows skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)