### PR TITLE
feat: add custom loading animation setting

### DIFF
--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -3849,6 +3849,27 @@ export class ChatContainer extends Component {
 			const dot = dots.createSpan({ cls: "streaming-dot" });
 			dot.textContent = ".";
 		}
+		if (this.plugin.settings.useSpecialAnimation) {
+			const svgWrap = this.streamingDiv.createDiv({ cls: "llm-special-animation" });
+			svgWrap.innerHTML = `<svg width="45" height="30" viewBox="0 0 30 20" fill="none" xmlns="http://www.w3.org/2000/svg" shape-rendering="crispEdges">
+  <g id="f1">
+    <path d="M18 19H17V18H18V19ZM24 7H25V8H22V10H21V11H20V13H19V14H18V16H17V18H16V16H13V15H17V14H16V13H13V12H12V13H10V15H9V13H8V12H10V11H9V10H8V11H6V10H7V9H11V8H13V9H18V8H20V7H21V5H22V6H24V7ZM7 16H6V15H7V16ZM11 16H10V15H11V16ZM8 15H7V13H8V15ZM6 12H5V11H6V12ZM5 11H4V10H5V11Z" fill="var(--interactive-accent)"/>
+    <animate attributeName="display" values="inline;none;none;none" keyTimes="0;0.25;0.5;0.75" calcMode="discrete" dur="0.5s" repeatCount="indefinite"/>
+  </g>
+  <g id="f2" display="none">
+    <path d="M15 16H16V17H13V16H14V15H15V16ZM24 7H25V8H22V10H21V11H20V15H19V14H18V15H19V16H16V15H17V14H16V13H15V12H13V14H14V15H13V16H12V15H11V14H12V13H11V12H10V11H9V10H8V9H11V8H19V7H20V6H21V5H22V6H24V7ZM11 14H10V13H11V14ZM5 11H6V12H4V10H5V11ZM8 11H6V10H8V11Z" fill="var(--interactive-accent)"/>
+    <animate attributeName="display" values="none;inline;none;none" keyTimes="0;0.25;0.5;0.75" calcMode="discrete" dur="0.5s" repeatCount="indefinite"/>
+  </g>
+  <g id="f3" display="none">
+    <path d="M25 7H26V8H23V10H22V13H23V15H22V14H21V13H20V14H19V16H16V15H18V13H16V12H15V14H16V15H12V13H13V14H14V13H13V12H11V10H10V11H7V10H9V9H12V8H20V7H21V6H22V5H23V6H25V7ZM22 16H20V15H22V16ZM7 12H5V11H7V12Z" fill="var(--interactive-accent)"/>
+    <animate attributeName="display" values="none;none;inline;none" keyTimes="0;0.25;0.5;0.75" calcMode="discrete" dur="0.5s" repeatCount="indefinite"/>
+  </g>
+  <g id="f4" display="none">
+    <path d="M16 18H15V17H16V18ZM24 7H25V8H22V9H21V12H23V16H22V13H20V14H19V15H20V16H18V14H17V13H15V12H14V14H16V15H14V16H15V17H13V16H12V13H11V12H10V10H9V11H6V12H4V11H5V10H8V9H11V8H19V7H20V6H21V5H22V6H24V7ZM17 16H16V15H17V16ZM21 15H20V14H21V15Z" fill="var(--interactive-accent)"/>
+    <animate attributeName="display" values="none;none;none;inline" keyTimes="0;0.25;0.5;0.75" calcMode="discrete" dur="0.5s" repeatCount="indefinite"/>
+  </g>
+</svg>`;
+		}
 		this.historyMessages.scroll(0, 9999);
 	}
 
@@ -4123,8 +4144,112 @@ export class ChatContainer extends Component {
 		// message when running in agent mode, mirroring how Claude shows its logo.
 		if (finalMessage && assistant && this.isObsidianAgent && this.plugin.settings.showAgentBrandIcon) {
 			const brandEl = messageWrapper.createDiv({ cls: "llm-obsidian-agent-brand" });
-			const iconEl = brandEl.createSpan({ cls: "llm-obsidian-agent-brand-icon" });
-			setIcon(iconEl, "stone");
+			if (this.plugin.settings.useSpecialAnimation) {
+				const svgEl = brandEl.createDiv({ cls: "llm-special-standing" });
+				svgEl.innerHTML = `<svg width="45" height="30" viewBox="0 0 30 20" fill="none" xmlns="http://www.w3.org/2000/svg" shape-rendering="crispEdges">
+<rect x="22" y="5" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="21" y="4" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="23" y="6" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="22" y="6" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="20" y="4" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="20" y="5" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="21" y="6" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="20" y="7" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="20" y="6" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="19" y="6" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="19" y="5" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="18" y="6" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="19" y="7" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="18" y="7" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="16" y="8" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="15" y="8" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="12" y="7" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="11" y="7" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="20" y="3" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="20" y="10" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="19" y="11" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="19" y="12" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="17" y="14" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="17" y="13" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="19" y="14" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="19" y="15" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="19" y="16" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="20" y="17" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="9" y="11" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="9" y="10" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="12" y="17" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="10" y="8" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="12" y="8" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="13" y="8" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="14" y="8" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="9" y="8" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="10" y="12" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="10" y="13" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="11" y="13" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="11" y="14" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="9" y="14" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="9" y="12" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="10" y="17" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="9" y="16" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="9" y="15" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="11" y="8" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="11" y="15" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="11" y="16" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="8" y="10" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="7" y="11" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="7" y="12" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="6" y="13" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="11" y="12" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="10" y="11" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="10" y="9" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="13" y="9" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="14" y="9" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="15" y="9" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="16" y="9" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="17" y="9" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="18" y="9" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="19" y="8" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="20" y="8" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="20" y="9" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="19" y="9" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="19" y="10" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="18" y="10" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="10" y="10" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="11" y="9" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="12" y="9" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="11" y="11" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="11" y="10" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="12" y="10" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="13" y="10" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="13" y="11" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="14" y="11" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="15" y="11" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="16" y="11" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="17" y="11" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="17" y="12" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="18" y="12" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="18" y="11" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="17" y="10" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="16" y="10" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="15" y="10" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="14" y="10" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="17" y="8" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="17" y="7" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="18" y="8" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="9" y="9" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="8" y="9" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="19" y="13" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="16" y="12" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="21" y="5" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="23" y="5" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="17" y="15" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="17" y="16" width="1" height="1" fill="var(--interactive-accent)"/>
+<rect x="18" y="17" width="1" height="1" fill="var(--interactive-accent)"/>
+</svg>`;
+			} else {
+				const iconEl = brandEl.createSpan({ cls: "llm-obsidian-agent-brand-icon" });
+				setIcon(iconEl, "stone");
+			}
 		}
 	}
 

--- a/src/Settings/LLMSettingsModal.ts
+++ b/src/Settings/LLMSettingsModal.ts
@@ -654,6 +654,7 @@ export class LLMSettingsModal extends Modal {
 
 	private renderInterface() {
 		const el = this.mainContentEl;
+		el.empty();
 		const items = this.addSettingGroup(el);
 
 		new Setting(items)
@@ -738,6 +739,42 @@ export class LLMSettingsModal extends Modal {
 						await this.plugin.saveSettings();
 					});
 			});
+
+		// Easter egg — unlock with passphrase
+		let unlocked = this.plugin.settings.useSpecialAnimation;
+		const eggSetting = new Setting(items)
+			.setName("Custom loading animation")
+			.setDesc("Replace the default thinking animation with a special one.");
+
+		if (unlocked) {
+			eggSetting.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.useSpecialAnimation)
+					.onChange(async (value) => {
+						this.plugin.settings.useSpecialAnimation = value;
+						await this.plugin.saveSettings();
+						if (!value) this.renderInterface();
+					});
+			});
+		} else {
+			eggSetting.addText((text) => {
+				text.setPlaceholder("Enter passphrase to unlock")
+					.inputEl.addClass("llm-egg-passphrase");
+				text.inputEl.type = "password";
+				text.inputEl.addEventListener("keydown", async (e) => {
+					if (e.key !== "Enter") return;
+					if (text.getValue().trim() === "frontier") {
+						this.plugin.settings.useSpecialAnimation = true;
+						await this.plugin.saveSettings();
+						this.renderInterface();
+					} else {
+						text.inputEl.addClass("llm-egg-error");
+						setTimeout(() => text.inputEl.removeClass("llm-egg-error"), 600);
+						text.setValue("");
+					}
+				});
+			});
+		}
 	}
 
 	/**

--- a/src/Settings/LLMSettingsModal.ts
+++ b/src/Settings/LLMSettingsModal.ts
@@ -654,7 +654,6 @@ export class LLMSettingsModal extends Modal {
 
 	private renderInterface() {
 		const el = this.mainContentEl;
-		el.empty();
 		const items = this.addSettingGroup(el);
 
 		new Setting(items)
@@ -740,41 +739,38 @@ export class LLMSettingsModal extends Modal {
 					});
 			});
 
-		// Easter egg — unlock with passphrase
-		let unlocked = this.plugin.settings.useSpecialAnimation;
+		// Easter egg — passphrase field always visible; toggle only active when correct
+		const alreadyUnlocked = this.plugin.settings.useSpecialAnimation;
+		let toggleComponent: import("obsidian").ToggleComponent;
 		const eggSetting = new Setting(items)
 			.setName("Custom loading animation")
-			.setDesc("Replace the default thinking animation with a special one.");
-
-		if (unlocked) {
-			eggSetting.addToggle((toggle) => {
+			.setDesc("Replace the default thinking animation with a special one.")
+			.addText((text) => {
+				text.setPlaceholder("Passphrase")
+					.inputEl.addClass("llm-egg-passphrase");
+				text.inputEl.type = "password";
+				if (alreadyUnlocked) text.setValue("frontier");
+				text.onChange((value) => {
+					const correct = value.trim() === "frontier";
+					toggleComponent.setDisabled(!correct);
+					if (!correct && this.plugin.settings.useSpecialAnimation) {
+						this.plugin.settings.useSpecialAnimation = false;
+						toggleComponent.setValue(false);
+						this.plugin.saveSettings();
+					}
+				});
+			})
+			.addToggle((toggle) => {
+				toggleComponent = toggle;
 				toggle
 					.setValue(this.plugin.settings.useSpecialAnimation)
+					.setDisabled(!alreadyUnlocked)
 					.onChange(async (value) => {
 						this.plugin.settings.useSpecialAnimation = value;
 						await this.plugin.saveSettings();
-						if (!value) this.renderInterface();
 					});
 			});
-		} else {
-			eggSetting.addText((text) => {
-				text.setPlaceholder("Enter passphrase to unlock")
-					.inputEl.addClass("llm-egg-passphrase");
-				text.inputEl.type = "password";
-				text.inputEl.addEventListener("keydown", async (e) => {
-					if (e.key !== "Enter") return;
-					if (text.getValue().trim() === "frontier") {
-						this.plugin.settings.useSpecialAnimation = true;
-						await this.plugin.saveSettings();
-						this.renderInterface();
-					} else {
-						text.inputEl.addClass("llm-egg-error");
-						setTimeout(() => text.inputEl.removeClass("llm-egg-error"), 600);
-						text.setValue("");
-					}
-				});
-			});
-		}
+		void eggSetting;
 	}
 
 	/**

--- a/src/main.ts
+++ b/src/main.ts
@@ -102,6 +102,7 @@ export interface LLMPluginSettings {
 	emptyChatAvatar: string;
 	fabViewHeight?: number;
 	showStatusBarButton: boolean;
+	useSpecialAnimation: boolean;
 	ragSettings: RAGSettings;
 	skillsSettings: SkillsSettings;
 	memorySettings: MemorySettings;
@@ -214,6 +215,7 @@ export const DEFAULT_SETTINGS: LLMPluginSettings = {
 	lmStudioModels: [],
 	emptyChatAvatar: "llm-gal",
 	showStatusBarButton: false,
+	useSpecialAnimation: false,
 	ragSettings: {
 		enabled: false,
 		embeddingProvider: "onnx" as const,

--- a/styles.css
+++ b/styles.css
@@ -1022,6 +1022,41 @@ div.im-like-message.llm-widget-chat-message > p {
 	}
 }
 
+.llm-egg-passphrase {
+	width: 100%;
+}
+
+.llm-egg-error {
+	animation: llm-egg-shake 0.4s ease;
+	border-color: var(--color-red) !important;
+}
+
+@keyframes llm-egg-shake {
+	0%, 100% { transform: translateX(0); }
+	20%       { transform: translateX(-4px); }
+	40%       { transform: translateX(4px); }
+	60%       { transform: translateX(-4px); }
+	80%       { transform: translateX(4px); }
+}
+
+.llm-special-standing {
+	display: flex;
+	align-items: center;
+}
+
+.llm-special-standing svg {
+	image-rendering: pixelated;
+}
+
+.llm-special-animation {
+	display: flex;
+	margin-top: 0.4em;
+}
+
+.llm-special-animation svg {
+	image-rendering: pixelated;
+}
+
 .llm-icon-wrapper {
 	display: flex;
 	flex-direction: column;

--- a/styles.css
+++ b/styles.css
@@ -1026,18 +1026,6 @@ div.im-like-message.llm-widget-chat-message > p {
 	width: 100%;
 }
 
-.llm-egg-error {
-	animation: llm-egg-shake 0.4s ease;
-	border-color: var(--color-red) !important;
-}
-
-@keyframes llm-egg-shake {
-	0%, 100% { transform: translateX(0); }
-	20%       { transform: translateX(-4px); }
-	40%       { transform: translateX(4px); }
-	60%       { transform: translateX(-4px); }
-	80%       { transform: translateX(4px); }
-}
 
 .llm-special-standing {
 	display: flex;


### PR DESCRIPTION
## Summary

- Adds a passphrase-protected "Custom loading animation" toggle in **Settings → Interface**
- When enabled, replaces the default thinking dots with a custom pixel animation below the "Thinking..." label
- Also replaces the Obsidian Agent brand icon at the bottom of responses with a matching static pixel variant
- Both graphics use `--interactive-accent` to inherit the user's theme color
- Passphrase field is always visible alongside the toggle; toggle is disabled until the correct passphrase is entered
- Clearing the passphrase field automatically disables the toggle
- On reload, if the feature was already enabled, the field pre-fills and the toggle remains active

## Test plan

- [ ] Navigate to Settings → Interface — confirm "Custom loading animation" row shows a passphrase field (empty) and a disabled toggle
- [ ] Enter correct passphrase → toggle becomes enabled
- [ ] Enable toggle → send a message in agent mode and confirm custom animation appears below "Thinking..." and agent brand icon is replaced
- [ ] Clear the passphrase field → toggle turns off automatically
- [ ] Re-enter passphrase → toggle re-enables with previous state
- [ ] Reload plugin with feature enabled → passphrase field pre-fills with dots, toggle remains active
- [ ] Confirm both graphics match the user's accent color across light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)