### PR TITLE
fix: plugin review issues, SDK install UX, and manifest linter

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,9 +3,9 @@
 	"version": "0.24.18",
 	"name": "Large Language Models",
 	"minAppVersion": "1.7.2",
-	"description": "Chat with LLMs (OpenAI, Claude, Gemini, Mistral, Ollama, LM Studio) directly in Obsidian. Includes Skills, Projects, Assistants, Memory, vault search, voice transcription, and an Obsidian Agent that can read and write your vault.",
+	"description": "Chat with LLMs (OpenAI, Claude, Gemini, Mistral, Ollama, LM Studio) directly in your notes. Includes Skills, Projects, Assistants, Memory, vault search, voice transcription, and an AI Agent that can read and write your vault.",
 	"author": "eharris128, r-mahoney, & jsmorabito",
-	"authorUrl": "https://github.com/eharris128/Obsidian-LLM-Plugin",
+	"authorUrl": "https://github.com/eharris128",
 	"fundingUrl": "https://www.buymeacoffee.com/johnny1093",
 	"isDesktopOnly": false
 }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
 	"main": "main.js",
 	"scripts": {
 		"dev": "node esbuild.config.mjs",
-		"build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
+		"build": "node scripts/check-manifest.mjs && tsc -noEmit -skipLibCheck && node esbuild.config.mjs production",
 		"lint": "eslint src",
 		"lint:fix": "eslint src --fix",
+		"lint:manifest": "node scripts/check-manifest.mjs",
 		"version": "node version-bump.mjs && git add manifest.json versions.json",
 		"test:e2e": "npm run build && tsc -noEmit -p test && node scripts/stage-plugin.mjs && wdio run ./wdio.conf.mts"
 	},

--- a/scripts/check-manifest.mjs
+++ b/scripts/check-manifest.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+// Fails if manifest.json is missing required fields or has an empty version.
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const manifestPath = resolve(root, "manifest.json");
+
+let manifest;
+try {
+	manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+} catch (e) {
+	console.error("manifest.json is missing or invalid JSON:", e.message);
+	process.exit(1);
+}
+
+const required = ["id", "version", "name", "minAppVersion"];
+const missing = required.filter((k) => !manifest[k]);
+
+if (missing.length > 0) {
+	console.error(`manifest.json is missing required fields: ${missing.join(", ")}`);
+	process.exit(1);
+}
+
+console.log(`manifest.json OK (version: ${manifest.version})`);

--- a/specs/context-window-fix.md
+++ b/specs/context-window-fix.md
@@ -1,0 +1,217 @@
+# Spec: Fix Context Window Budget Calculation
+
+## Problem
+
+The "Context token budget (%)" setting is broken by design. The budget is
+calculated as:
+
+```
+context budget = maxTokens * contextPercent / 100
+```
+
+`maxTokens` is the **response length** setting (currently defaulting to 300),
+not the model's context window. So with default settings, only 210 tokens are
+budgeted for context — regardless of whether the model supports 200,000. The
+two concepts need to be separated.
+
+## Goal
+
+Use each model's actual context window size as the basis for context budget
+calculation, while keeping `maxTokens` as a response-length-only control.
+
+---
+
+## Changes Required
+
+### 1. `src/Types/types.ts` — Add `contextWindow` to `Model`
+
+```typescript
+export type Model = {
+    model: string;
+    type: string;
+    endpoint: string;
+    url: string;
+    contextWindow?: number; // model's input context limit in tokens
+};
+```
+
+### 2. `src/utils/models.ts` — Populate `contextWindow` for all known models
+
+Add `contextWindow` to every entry in the `models` record. Use the values
+below. For `buildOllamaModels`, add an optional `contextWindows` parameter
+(a `Record<string, number>` mapping model name → num_ctx from Ollama's API).
+
+**Cloud model context windows:**
+
+| Model | contextWindow |
+|---|---|
+| ChatGPT-3.5 turbo | 16_385 |
+| GPT-4o | 128_000 |
+| GPT-4o-mini | 128_000 |
+| GPT-4.1 | 1_047_576 |
+| GPT-4.1-mini | 1_047_576 |
+| GPT-4.1-nano | 1_047_576 |
+| o3 | 200_000 |
+| o3-mini | 200_000 |
+| o4-mini | 200_000 |
+| Claude Sonnet 4.6 | 200_000 |
+| Claude Opus 4.6 | 200_000 |
+| Claude Haiku 4.5 | 200_000 |
+| Gemini-3-Pro-Preview | 1_048_576 |
+| Gemini-2.5-Pro | 1_048_576 |
+| Gemini-2.5-Flash | 1_048_576 |
+| Gemini-2.5-Flash-Lite | 1_048_576 |
+| Gemini-2.0-Flash | 1_048_576 |
+| Gemini-2.0-Flash-Lite | 1_048_576 |
+| Gemini-Flash-Latest | 1_048_576 |
+| Gemini-Flash-Lite-Latest | 1_048_576 |
+| Mistral Large | 131_072 |
+| Mistral Medium | 131_072 |
+| Mistral Small | 131_072 |
+| Mistral Nemo | 131_072 |
+| Magistral Medium | 131_072 |
+| Magistral Small | 131_072 |
+| Devstral Small | 131_072 |
+| Codestral | 131_072 |
+| GPT4All models | 8_192 (fallback) |
+| Claude Code | 200_000 |
+
+Update `buildOllamaModels` signature:
+
+```typescript
+export function buildOllamaModels(
+    ollamaModelNames: string[],
+    contextWindows: Record<string, number> = {}
+): { models: Record<string, Model>, names: Record<string, string> } {
+    // For each name, set contextWindow: contextWindows[name] ?? 8_192
+}
+```
+
+### 3. `src/utils/utils.ts` — Add `fetchOllamaContextWindows`
+
+Add a new exported function alongside `fetchOllamaModels`. It calls Ollama's
+`/api/show` endpoint for each discovered model name and extracts `num_ctx`
+from the response.
+
+```typescript
+export async function fetchOllamaContextWindows(
+    host: string,
+    modelNames: string[]
+): Promise<Record<string, number>> {
+    const result: Record<string, number> = {};
+    for (const name of modelNames) {
+        try {
+            const response = await requestUrl({
+                url: `${host}/api/show`,
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ name }),
+            }).then((res) => res.json);
+            // num_ctx lives at model_info["llm.context_length"] or
+            // parameters.num_ctx depending on Ollama version — check both
+            const fromInfo = response?.model_info?.["llm.context_length"];
+            const fromParams = response?.parameters
+                ? parseInt(
+                      (response.parameters as string)
+                          .split("\n")
+                          .find((l: string) => l.startsWith("num_ctx"))
+                          ?.split(/\s+/)[1] ?? ""
+                  )
+                : NaN;
+            const ctx = fromInfo ?? (isNaN(fromParams) ? undefined : fromParams);
+            if (ctx && ctx > 0) result[name] = ctx;
+        } catch {
+            // silently skip — 8_192 fallback applies in buildOllamaModels
+        }
+    }
+    return result;
+}
+```
+
+### 4. `src/Settings/SettingsView.ts` — Call `fetchOllamaContextWindows` on refresh
+
+In the Ollama "Refresh" button `onClick` handler (around line 229), after
+`fetchOllamaModels` returns `foundModels`, call `fetchOllamaContextWindows`
+and pass the result into `buildOllamaModels`. Also persist the context windows
+map to settings so it survives reload (see §5).
+
+```typescript
+const foundModels = await fetchOllamaModels(this.plugin.settings.ollamaHost);
+const ctxWindows = await fetchOllamaContextWindows(
+    this.plugin.settings.ollamaHost,
+    foundModels
+);
+this.plugin.settings.ollamaModels = foundModels;
+this.plugin.settings.ollamaContextWindows = ctxWindows;
+const built = buildOllamaModels(foundModels, ctxWindows);
+// ... rest of existing handler unchanged
+```
+
+### 5. `src/main.ts` — Persist and restore Ollama context windows
+
+Add `ollamaContextWindows: Record<string, number>` to the `LLMPluginSettings`
+type and its default value (`{}`).
+
+Update `registerOllamaModels()` to pass the stored context windows:
+
+```typescript
+private registerOllamaModels() {
+    if (this.settings.ollamaModels.length > 0) {
+        const built = buildOllamaModels(
+            this.settings.ollamaModels,
+            this.settings.ollamaContextWindows ?? {}
+        );
+        Object.assign(models, built.models);
+        Object.assign(modelNames, built.names);
+    }
+}
+```
+
+### 6. `src/Plugin/Components/ChatContainer.ts` — Use `contextWindow`, not `maxTokens`
+
+Around line 619, replace the `maxTokens` fallback with a lookup of the
+selected model's `contextWindow`:
+
+```typescript
+// Before:
+const maxTokens = this.plugin.settings[settingType].chatSettings.maxTokens || 16384;
+
+// After:
+const selectedModelKey = this.plugin.settings[settingType].modelName;
+const selectedModel = models[selectedModelKey];
+const contextWindowSize = selectedModel?.contextWindow ?? 8_192;
+```
+
+Then pass `contextWindowSize` (not `maxTokens`) into `calculateContextTokenBudget`:
+
+```typescript
+const contextTokenBudget = this.contextBuilder.calculateContextTokenBudget(
+    contextWindowSize,   // ← was maxTokens
+    contextSettings.maxContextTokensPercent
+);
+```
+
+`ContextBuilder.calculateContextTokenBudget` itself does not need to change.
+
+---
+
+## What Does NOT Change
+
+- The "Tokens" setting continues to control max response length — it is passed
+  as `max_tokens` / `tokens` in API payloads unchanged.
+- The "Context token budget (%)" setting UI is unchanged — it now correctly
+  means "% of the model's context window to reserve for injected context."
+- `ContextBuilder.calculateContextTokenBudget` is unchanged.
+- No new UI is needed. The fix is entirely in the data layer and one call-site.
+
+---
+
+## Testing
+
+1. Set Context token budget to 70%. With Claude Sonnet 4.6 selected, verify
+   via a log or debugger that `contextTokenBudget` is ~140,000, not 210.
+2. With an Ollama model selected, click "Refresh" in settings, then verify
+   `plugin.settings.ollamaContextWindows` contains a non-zero entry for each
+   model. Verify `contextWindowSize` uses that value in `ChatContainer`.
+3. Confirm the "Tokens" (max response) setting still has no effect on context
+   window size.

--- a/specs/onnx-embeddings.md
+++ b/specs/onnx-embeddings.md
@@ -1,0 +1,203 @@
+# Spec: ONNX Local Embeddings (Replace Ollama Dependency)
+
+## Context & Problem
+
+The plugin already has a working RAG/embeddings system (visible in `main.js` and `rag-index.json`), but **its TypeScript source files are missing from `src/`** — they were never committed to git. The compiled `main.js` contains functions like `extractRagSourcePaths`, `formatRagResultsAsContext`, `registerRagVaultEvents`, etc., and `rag-index.json` contains 24 vault files indexed as 768-dim vectors using `nomic-embed-text` via Ollama.
+
+**The core problem with the current approach:** it requires Ollama to be running as a separate background server. If Ollama isn't running, embeddings silently fail. The ONNX approach runs a quantized embedding model entirely inside the plugin process — no external server needed.
+
+## Goal
+
+Replace the Ollama embedding dependency with an in-process ONNX model via `@huggingface/transformers` (Transformers.js). The rest of the RAG pipeline (chunking, indexing, cosine similarity retrieval, context injection) should remain structurally intact.
+
+## Recommended Model
+
+**`Xenova/nomic-embed-text-v1.5`** — quantized ONNX version of nomic-embed-text.
+- 768-dim output (drop-in compatible with existing `rag-index.json` vectors)
+- ~90MB download cached to disk on first use
+- Fully offline after first run
+- Used successfully in other Obsidian plugins (Smart Connections)
+
+Fallback option: `Xenova/all-MiniLM-L6-v2` (384-dim, ~25MB) if bundle size is a concern — but requires re-indexing since dimension changes.
+
+## Implementation Steps
+
+### 1. Add dependency
+
+```bash
+npm install @huggingface/transformers
+```
+
+Add to `esbuild.config.mjs` externals if needed; `@huggingface/transformers` should bundle fine with esbuild targeting CommonJS.
+
+### 2. Create `src/services/EmbeddingService.ts`
+
+```typescript
+import { pipeline, FeatureExtractionPipeline } from "@huggingface/transformers";
+
+export type EmbeddingVector = number[];
+
+export class EmbeddingService {
+  private static instance: EmbeddingService | null = null;
+  private pipe: FeatureExtractionPipeline | null = null;
+  private modelId = "Xenova/nomic-embed-text-v1.5";
+  private loading = false;
+  private loadPromise: Promise<void> | null = null;
+
+  static getInstance(): EmbeddingService {
+    if (!EmbeddingService.instance) {
+      EmbeddingService.instance = new EmbeddingService();
+    }
+    return EmbeddingService.instance;
+  }
+
+  async load(onProgress?: (progress: number) => void): Promise<void> {
+    if (this.pipe) return;
+    if (this.loadPromise) return this.loadPromise;
+
+    this.loadPromise = (async () => {
+      this.loading = true;
+      this.pipe = await pipeline("feature-extraction", this.modelId, {
+        quantized: true,
+        progress_callback: onProgress
+          ? (p: any) => onProgress(p.progress ?? 0)
+          : undefined,
+      });
+      this.loading = false;
+    })();
+    return this.loadPromise;
+  }
+
+  isLoaded(): boolean {
+    return this.pipe !== null;
+  }
+
+  async embed(texts: string[]): Promise<EmbeddingVector[]> {
+    if (!this.pipe) throw new Error("EmbeddingService not loaded");
+    const output = await this.pipe(texts, { pooling: "mean", normalize: true });
+    return Array.from({ length: texts.length }, (_, i) =>
+      Array.from(output[i].data as Float32Array)
+    );
+  }
+
+  async embedOne(text: string): Promise<EmbeddingVector> {
+    const results = await this.embed([text]);
+    return results[0];
+  }
+
+  cosineSimilarity(a: EmbeddingVector, b: EmbeddingVector): number {
+    let dot = 0, normA = 0, normB = 0;
+    for (let i = 0; i < a.length; i++) {
+      dot += a[i] * b[i];
+      normA += a[i] * a[i];
+      normB += b[i] * b[i];
+    }
+    return dot / (Math.sqrt(normA) * Math.sqrt(normB) + 1e-8);
+  }
+}
+```
+
+### 3. Update `src/services/RagService.ts` (recover or rewrite)
+
+The source for `RagService` is missing. Reconstruct it based on what's visible in `main.js`. Key responsibilities:
+
+**Indexing:**
+- Walk vault files (respect `ragSettings.excludedFolders`)
+- Split each file into overlapping chunks (~500 tokens, 50-token overlap)
+- Call `EmbeddingService.embed()` on each chunk (batch in groups of 32)
+- Store results as `{ filePath, mtime, chunks: [{ text, vector }] }` in `rag-index.json`
+- Skip files whose `mtime` hasn't changed since last index (incremental update)
+
+**Retrieval:**
+- Accept a query string
+- Embed it with `EmbeddingService.embedOne(query)`
+- Score all chunks with cosine similarity
+- Return top-K chunks (default `ragSettings.topK = 5`), deduplicated by file
+
+**Context formatting:**
+- Format retrieved chunks as a `## Vault Context` block prepended to the system prompt
+- Include source file path for each chunk
+
+**Vault event registration:**
+- Watch `vault.on('modify')` and `vault.on('delete')` to update index incrementally (debounced 2s)
+
+### 4. Update Settings UI (`src/Settings/SettingsView.ts`)
+
+Replace the Ollama embedding provider dropdown with a single ONNX toggle. Remove `embeddingProvider` and `embeddingModel` settings (no longer user-configurable). Add:
+
+- **Enable Embeddings** toggle — triggers model download on first enable, shows progress bar
+- **Re-index Vault** button — clears and rebuilds full index
+- **Excluded Folders** — path list to skip during indexing
+- **Top K Results** — number of chunks to inject (default 5)
+- Model download status indicator (e.g., "Model ready" / "Downloading… 43%")
+
+### 5. Update `src/Types/types.ts`
+
+```typescript
+export interface RagSettings {
+  enabled: boolean;
+  excludedFolders: string[];
+  topK: number;
+  lastIndexed: number | null;
+  indexedFileCount: number;
+  modelCached: boolean; // new: tracks whether ONNX model is on disk
+}
+```
+
+Remove `embeddingProvider` and `embeddingModel` fields.
+
+### 6. Wire into `src/main.ts`
+
+```typescript
+// On plugin load, if rag enabled and model cached, warm up EmbeddingService
+if (settings.ragSettings.enabled && settings.ragSettings.modelCached) {
+  EmbeddingService.getInstance().load();
+}
+```
+
+### 7. Wire into `src/Plugin/Components/ChatContainer.ts`
+
+Before each API call, if RAG is enabled and model is loaded:
+
+```typescript
+const ragContext = await RagService.getInstance().retrieve(userMessage);
+if (ragContext) {
+  systemPrompt = ragContext + "\n\n" + systemPrompt;
+}
+```
+
+## Migration
+
+- Existing `rag-index.json` vectors (768-dim from nomic-embed-text) are **compatible** with `nomic-embed-text-v1.5` ONNX — no re-index required on first upgrade.
+- If user was previously using a different Ollama model (non-768-dim), detect dimension mismatch on load and prompt re-index.
+
+## Bundle Size Considerations
+
+`@huggingface/transformers` with a quantized model will increase bundle size. The ONNX model files (~90MB) are downloaded and cached to disk (Obsidian's plugin data directory) on first use — they are **not** bundled into `main.js`. Esbuild should handle the JS portion of `@huggingface/transformers` without issues (~500KB minified).
+
+If Electron's Node.js environment causes issues with WASM loading, use the `env.backends.onnx.wasm.wasmPaths` config to point at CDN-hosted WASM, or bundle the WASM files explicitly.
+
+## What to Recover from `main.js`
+
+Before writing new code, search `main.js` for these function names and extract the logic as a starting point:
+
+- `extractRagSourcePaths`
+- `formatRagResultsAsContext`
+- `ragContext`
+- `ragEnabled`
+- `ragResults`
+- `registerRagVaultEvents`
+- `ragDebounceTimers`
+- `pendingRagSources`
+
+These implementations already handle edge cases specific to this codebase and should be the base for recovery, not a rewrite from scratch.
+
+## Acceptance Criteria
+
+1. With Ollama **not running**, embeddings index and retrieval still work
+2. First enable triggers model download with visible progress
+3. Subsequent loads are instant (model cached to disk)
+4. Vault queries return semantically relevant chunks, not just keyword matches
+5. Existing `rag-index.json` loads without re-indexing (dimension check passes)
+6. Incremental index update fires on file save (debounced)
+7. TypeScript source for the full RAG feature is committed to `src/`

--- a/specs/smart-response-length.md
+++ b/specs/smart-response-length.md
@@ -1,0 +1,226 @@
+# Spec: Smart Response Length
+
+## Problem
+
+`chatSettings.maxTokens` is a flat user-set number (default 300) that caps
+response length. This is wrong for two reasons:
+
+1. **Cloud models** don't need a cap at all — they stop naturally when done.
+   Forcing 300 tokens truncates most meaningful answers.
+2. **Local models** (Ollama, GPT4All) need a cap, but the right value is
+   dynamic: whatever space remains in the context window after context
+   injection. A fixed number risks the model running past its window or
+   needlessly cutting off responses.
+
+## Goal
+
+- Cloud models: send no `max_tokens` cap by default (let the model decide),
+  with `model.maxOutputTokens` as a safety ceiling.
+- Local models: compute the response cap dynamically as
+  `contextWindow - contextTokenBudget`, floored at 1024.
+- The user's "Tokens" setting becomes an **optional manual override** — when
+  set to 0, the smart default applies. When set to a positive number, that
+  value is used as a hard cap (cannot exceed `model.maxOutputTokens`).
+- Update the "Tokens" setting description and default to reflect this.
+
+---
+
+## Changes Required
+
+### 1. `src/Types/types.ts` — Add `maxOutputTokens` to `Model`
+
+```typescript
+export type Model = {
+    model: string;
+    type: string;
+    endpoint: string;
+    url: string;
+    contextWindow?: number;
+    maxOutputTokens?: number; // model's max response length; undefined = no cap
+};
+```
+
+### 2. `src/utils/models.ts` — Populate `maxOutputTokens` for all known models
+
+Add `maxOutputTokens` alongside `contextWindow` on every model entry.
+
+| Model | maxOutputTokens |
+|---|---|
+| ChatGPT-3.5 turbo | 4_096 |
+| GPT-4o | 16_384 |
+| GPT-4o-mini | 16_384 |
+| GPT-4.1 | 32_768 |
+| GPT-4.1-mini | 32_768 |
+| GPT-4.1-nano | 32_768 |
+| o3 | 100_000 |
+| o3-mini | 65_536 |
+| o4-mini | 100_000 |
+| Claude Sonnet 4.6 | 64_000 |
+| Claude Opus 4.6 | 32_000 |
+| Claude Haiku 4.5 | 16_000 |
+| All Gemini models | 65_536 |
+| All Mistral/Magistral models | 32_768 |
+| Claude Code | 64_000 |
+| GPT4All models | leave undefined (dynamic) |
+| Ollama models | leave undefined (dynamic) |
+
+Also update `buildOllamaModels` — Ollama models should have no
+`maxOutputTokens` set (undefined), so the dynamic calculation kicks in.
+
+### 3. `src/main.ts` — Change default `maxTokens` to 0
+
+In `DEFAULT_SETTINGS`, set `maxTokens: 0` for all view settings. 0 is the
+sentinel value meaning "use smart default."
+
+Also update the `LLMPluginSettings` type if `maxTokens` has a non-zero
+hardcoded default anywhere.
+
+### 4. `src/Plugin/Components/SettingsContainer.ts` — Update "Tokens" setting UI
+
+Around line 343, update the setting description to reflect that 0 means
+automatic:
+
+```typescript
+.setName("Max response tokens")
+.setDesc(
+    "Maximum tokens in the response. Set to 0 (recommended) to let the " +
+    "model decide — cloud models stop naturally, local models use the " +
+    "remaining context window. Set a positive number to enforce a hard cap."
+)
+```
+
+The input field itself does not need to change.
+
+### 5. `src/services/ContextBuilder.ts` — Add `estimateTokens` helper
+
+Add a static helper the rest of the code can use for rough token counts.
+The existing `truncateToTokenLimit` already uses the `chars / 4` heuristic —
+just expose it:
+
+```typescript
+static estimateTokens(text: string): number {
+    return Math.ceil(text.length / 4);
+}
+```
+
+### 6. `src/Plugin/Components/ChatContainer.ts` — Compute effective max tokens
+
+This is the core change. Replace the fixed `maxTokens` lookup (line 619)
+with a `resolveEffectiveMaxTokens()` helper and call it before the API call.
+
+Add a private method to `ChatContainer`:
+
+```typescript
+private resolveEffectiveMaxTokens(
+    contextTokenBudget: number
+): number {
+    const settingType = getSettingType(this.viewType);
+    const userMax = this.plugin.settings[settingType].chatSettings.maxTokens;
+    const selectedModelKey = this.plugin.settings[settingType].modelName;
+    const selectedModel = models[selectedModelKey];
+    const modelType = this.plugin.settings[settingType].modelType;
+
+    const isLocal = modelType === "ollama" || modelType === "GPT4All";
+
+    if (isLocal) {
+        // For local models: remaining context window space, floored at 1024
+        const contextWindow = selectedModel?.contextWindow ?? 8_192;
+        const remaining = contextWindow - contextTokenBudget;
+        const dynamicMax = Math.max(remaining, 1024);
+        // User override: respect it only if it's positive and smaller
+        return userMax > 0 ? Math.min(userMax, dynamicMax) : dynamicMax;
+    }
+
+    // Cloud models: no cap by default (send 0 / omit), use maxOutputTokens as ceiling
+    const modelCeiling = selectedModel?.maxOutputTokens;
+    if (userMax > 0) {
+        return modelCeiling ? Math.min(userMax, modelCeiling) : userMax;
+    }
+    // 0 = let the model decide; return 0 and the API call omits the field
+    return 0;
+}
+```
+
+Then in `handleGenerateClick` (around line 619), replace:
+
+```typescript
+// Before:
+const maxTokens = this.plugin.settings[settingType].chatSettings.maxTokens || 16384;
+const contextTokenBudget = this.contextBuilder.calculateContextTokenBudget(
+    maxTokens,
+    contextSettings.maxContextTokensPercent
+);
+```
+
+With (note: context window fix from previous spec must already be in place):
+
+```typescript
+const selectedModelKey = this.plugin.settings[settingType].modelName;
+const selectedModel = models[selectedModelKey];
+const contextWindowSize = selectedModel?.contextWindow ?? 8_192;
+
+const contextTokenBudget = this.contextBuilder.calculateContextTokenBudget(
+    contextWindowSize,
+    contextSettings.maxContextTokensPercent
+);
+
+const effectiveMaxTokens = this.resolveEffectiveMaxTokens(contextTokenBudget);
+```
+
+### 7. `src/Plugin/Components/ChatContainer.ts` — Pass `effectiveMaxTokens` to API calls
+
+Wherever `params` is built via `getParams()`, the `tokens` field comes from
+`chatSettings.maxTokens`. After computing `effectiveMaxTokens` above, override
+it on the params object before the API call:
+
+```typescript
+const params = this.getParams(modelEndpoint, model, modelType);
+// Override tokens with the smart-computed value
+if ("tokens" in params) {
+    (params as ChatParams).tokens = effectiveMaxTokens || undefined;
+    // undefined causes the field to be omitted from the API payload (no cap)
+}
+```
+
+In the API call layer (`utils/utils.ts` and provider-specific functions),
+ensure that when `tokens` is `undefined` or `0`, the `max_tokens` field is
+omitted from the request body rather than sent as 0. Most providers treat
+a missing field as "no limit" and `0` as invalid. Check each provider's
+send logic and add a guard:
+
+```typescript
+// Only include max_tokens if tokens is a positive number
+if (params.tokens && params.tokens > 0) {
+    payload.max_tokens = params.tokens;
+}
+```
+
+---
+
+## What Does NOT Change
+
+- The "Tokens" setting remains in the UI — it is now an optional override
+  rather than a required value.
+- `calculateContextTokenBudget` is unchanged.
+- The context budget percentage logic is unchanged.
+- This spec depends on the context window fix (`context-window-fix.md`) being
+  implemented first. `contextWindowSize` must come from `model.contextWindow`,
+  not `maxTokens`.
+
+---
+
+## Testing
+
+1. Select a Claude model, set Tokens to 0. Send a long-form request ("write
+   me a detailed explanation of X"). Verify the response is not cut off at
+   300 tokens.
+2. Select an Ollama model with an 8k context window and 70% context budget.
+   Log `effectiveMaxTokens` — should be approximately
+   `8192 - (8192 * 0.70) = 2457`, not 300.
+3. Set Tokens to 500 with a Claude model selected. Verify the response stops
+   at 500 tokens (manual override respected).
+4. Set Tokens to 500 with an Ollama model on a small context window where the
+   dynamic cap would be 300. Verify the response caps at 300 (dynamic wins
+   because it's lower).
+5. Verify no API errors — specifically that `max_tokens: 0` is never sent to
+   any provider.

--- a/specs/system-prompt-tool-disambiguation.md
+++ b/specs/system-prompt-tool-disambiguation.md
@@ -1,0 +1,65 @@
+# Spec: System Prompt Tool Disambiguation + Learning Loop
+
+## Background
+
+The Obsidian Agent's `buildSystemPrompt()` method constructs the system prompt that governs agent behavior. Two issues have been identified:
+
+1. **Tool confusion bug**: Small models (e.g. 9B parameter local models) conflate `grep_vault`/`search_vault_semantic` (local vault search) with `web_search` (internet search). When asked to follow up on a web search result, they call `grep_vault` instead. The root cause is that the system prompt doesn't explicitly distinguish the two categories of tools or provide negative examples.
+
+2. **No learning loop**: Users have no way to teach the agent their preferences without editing plugin source. The plugin already supports an `agentGuidanceFile` vault note that is appended to the system prompt each turn — this is the right mechanism, but the agent isn't instructed to use it for self-updating.
+
+---
+
+## Changes Required
+
+All changes are in `buildSystemPrompt()`. The method lives in the source file that compiles into the agent section of `main.js` (search for `buildSystemPrompt` to locate it).
+
+### 1. Add tool category boundary to the Vault Search Strategy section
+
+**Current text** (the section pushed into `parts` as "Vault Search Strategy"):
+
+```
+For any vault search, run BOTH tools and combine unique files before responding:
+
+1. **`grep_vault`** — exact/near-exact matches. ...
+2. **`search_vault_semantic`** — conceptual/thematic matches. ...
+
+Never rely on only one tool — grep misses paraphrases, semantic search misses exact terms.
+```
+
+**Change**: Add a clarifying rule at the end of this section, after "Never rely on only one tool...":
+
+```
+`grep_vault` and `search_vault_semantic` search **local vault notes only** — they have no access to the internet. Never use them to follow up on a web search result or fetch online information. For anything internet-facing, use `web_search`.
+```
+
+### 2. Add a learning loop instruction
+
+The plugin already reads `settings.agentGuidanceFile` and appends it to the system prompt as `## Vault Guidance`. Add a new `parts.push(...)` block **before** the guidance file section (so the instruction appears before the guidance content). The new section should read:
+
+```
+## Learning Loop
+
+If the user expresses a persistent behavioral preference — using phrases like "remember that", "always", "never", "from now on", or "I prefer" — update the agent guidance file at `<agentGuidancePath>` to record the new preference, then confirm the update. If no guidance file is configured, tell the user to set one in plugin settings.
+
+Do not update the guidance file for one-off requests or task-specific instructions. Only write preferences that should apply to all future conversations.
+```
+
+Where `<agentGuidancePath>` is the runtime value of `settings.agentGuidanceFile` (interpolate it into the string the same way `chatFolder` is used elsewhere in this method). If no guidance file is configured, use the fallback text `"the agent guidance file (not yet configured — ask the user to set one in plugin settings)"`.
+
+---
+
+## Acceptance Criteria
+
+- When a user asks the agent to "go deeper" or "find more" after a `web_search` turn, the agent calls `web_search` again, not `grep_vault`.
+- When a user says "remember that you should always use bullet points", the agent appends that preference to the configured guidance file and confirms.
+- When no guidance file is configured and the user tries to teach a preference, the agent informs the user they need to configure one in settings.
+- No behavior change for normal vault searches or web searches initiated from scratch.
+
+---
+
+## Notes
+
+- Do not change the `agentGuidanceFile` read logic — only add the learning loop instruction before it.
+- The guidance file path is already available as `settings.agentGuidanceFile` within `buildSystemPrompt()`.
+- This is a prompt-only change; no new tools, settings, or UI are required.

--- a/src/Assistants/AssistantManager.ts
+++ b/src/Assistants/AssistantManager.ts
@@ -219,7 +219,7 @@ ${systemPrompt || "<!-- Add your assistant's system prompt / persona instruction
 		try {
 			const file = this.app.vault.getFileByPath(assistant.filePath);
 			if (file) {
-				await this.app.vault.trash(file, true);
+				await this.app.fileManager.trashFile(file);
 			}
 			this.assistants.delete(id);
 		} catch (e) {

--- a/src/History/HistoryHandler.ts
+++ b/src/History/HistoryHandler.ts
@@ -8,7 +8,7 @@ export class History {
 		// When file-based history is active, writes are handled by ChatHistory.
 		if (this.plugin.settings.chatHistoryEnabled) return true;
 		try {
-			let history = this.plugin.settings.promptHistory;
+			const history = this.plugin.settings.promptHistory;
 			history.push(message_context);
 			this.plugin.settings.promptHistory = history;
 			void this.plugin.saveSettings();

--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -188,7 +188,7 @@ export class ChatContainer extends Component {
 	 */
 	private activeSkillId: string | null = null;
 	/**
-	 * The floating slash-command menu element mounted on document.body.
+	 * The floating slash-command menu element mounted on activeDocument.body.
 	 * Stored here so each ChatContainer instance manages only its own menu —
 	 * prevents other views' generateChatContainer calls from removing it.
 	 */
@@ -857,7 +857,7 @@ export class ChatContainer extends Component {
 		if (modelType === GPT4All) {
 			this.plugin.settings.GPT4AllStreaming = true;
 			this.setDiv(false);
-			messageGPT4AllServer(params as ChatParams, endpointURL).then(
+			void messageGPT4AllServer(params as ChatParams, endpointURL).then(
 				(response: Message) => {
 					this.streamingDiv.textContent = response.content;
 					this.messageStore.addMessage(response);
@@ -1600,7 +1600,7 @@ export class ChatContainer extends Component {
 			this.activeAssistantNameThisTurn = null;
 			errorMessages(error, params);
 			if (this.getMessages().length > 0) {
-				activeWindow.setTimeout(() => {
+				window.setTimeout(() => {
 					this.removeMessage(header, modelName);
 				}, 1000);
 			}
@@ -2701,8 +2701,8 @@ export class ChatContainer extends Component {
 
 		// Project chip — icon-only at rest, name revealed on hover
 		if (hasProject && activeProject) {
-			this.buildProjectChip(this.chipContainer, activeProject.name, () => {
-				this.setActiveProject(null);
+			void this.buildProjectChip(this.chipContainer, activeProject.name, () => {
+				void this.setActiveProject(null);
 			});
 		}
 
@@ -2814,7 +2814,7 @@ export class ChatContainer extends Component {
 		if (file) {
 			chip.addClass("llm-context-chip--clickable");
 			chip.addEventListener("click", () => {
-				this.plugin.app.workspace.getLeaf(false).openFile(file);
+				void this.plugin.app.workspace.getLeaf(false).openFile(file);
 			});
 		}
 		return chip;
@@ -2908,12 +2908,12 @@ export class ChatContainer extends Component {
 			this.auto_height(promptField, parentElement);
 		});
 
-		// Slash command picker menu — mounted on document.body with position:fixed
+		// Slash command picker menu — mounted on activeDocument.body with position:fixed
 		// so it is never clipped by overflow:hidden/auto on any ancestor container.
 		// Each ChatContainer instance manages only its own menu via this.slashMenuEl,
 		// so other views' menus are not accidentally removed.
 		this.slashMenuEl?.remove();
-		this.slashMenuEl = document.body.createDiv({ cls: "llm-slash-menu" });
+		this.slashMenuEl = activeDocument.body.createDiv({ cls: "llm-slash-menu" });
 		const slashMenu = this.slashMenuEl;
 		slashMenu.addClass("llm-hidden");
 		let slashMenuIndex = 0;
@@ -2947,13 +2947,13 @@ export class ChatContainer extends Component {
 
 		// Clean up the body-mounted menu if the prompt container leaves the DOM.
 		const cleanupObserver = new MutationObserver(() => {
-			if (!document.contains(promptContainer)) {
+			if (!activeDocument.contains(promptContainer)) {
 				slashMenu.remove();
 				window.removeEventListener("resize", repositionHandler);
 				cleanupObserver.disconnect();
 			}
 		});
-		cleanupObserver.observe(document.body, { childList: true, subtree: false });
+		cleanupObserver.observe(activeDocument.body, { childList: true, subtree: false });
 
 		// "Attach local path" is a built-in slash command that opens the OS file picker.
 		// It matches /attach (and any prefix like /att, /a, /).
@@ -3026,7 +3026,7 @@ export class ChatContainer extends Component {
 					hideSlashMenu();
 					const file = this.plugin.app.vault.getAbstractFileByPath(skill.filePath);
 					if (file instanceof TFile) {
-						this.plugin.app.workspace.getLeaf(false).openFile(file);
+						void this.plugin.app.workspace.getLeaf(false).openFile(file);
 					}
 				});
 
@@ -3180,14 +3180,14 @@ export class ChatContainer extends Component {
 		modelDropdown.selectEl.addClass("llm-model-select");
 
 		// ── Models optgroup ───────────────────────────────────────────────────
-		const modelsGroup = document.createElement("optgroup");
+		const modelsGroup = activeDocument.createElement("optgroup");
 		modelsGroup.label = "Models";
 		const { openAIAPIKey, claudeAPIKey, geminiAPIKey, mistralAPIKey } = this.plugin.settings;
 		for (const modelDisplayName of Object.keys(models)) {
 			const type = models[modelDisplayName].type;
 			// Local providers: always show
 			if (type === ollama || type === lmStudio) {
-				const opt = document.createElement("option");
+				const opt = activeDocument.createElement("option");
 				opt.value = models[modelDisplayName].model;
 				opt.text = modelDisplayName;
 				modelsGroup.appendChild(opt);
@@ -3198,7 +3198,7 @@ export class ChatContainer extends Component {
 				const gpt4AllPath = getGpt4AllPath(this.plugin);
 				const fullPath = `${gpt4AllPath}/${models[modelDisplayName].model}`;
 				if (this.plugin.fileSystem.existsSync(fullPath)) {
-					const opt = document.createElement("option");
+					const opt = activeDocument.createElement("option");
 					opt.value = models[modelDisplayName].model;
 					opt.text = modelDisplayName;
 					modelsGroup.appendChild(opt);
@@ -3210,7 +3210,7 @@ export class ChatContainer extends Component {
 			if ((type === claude || type === claudeCode) && !claudeAPIKey) continue;
 			if (type === gemini && !geminiAPIKey) continue;
 			if (type === mistral && !mistralAPIKey) continue;
-			const opt = document.createElement("option");
+			const opt = activeDocument.createElement("option");
 			opt.value = models[modelDisplayName].model;
 			opt.text = modelDisplayName;
 			modelsGroup.appendChild(opt);
@@ -3220,18 +3220,18 @@ export class ChatContainer extends Component {
 		// ── Assistants optgroup ──────────────────────────────────────────────
 		// Includes the built-in "Obsidian Agent" entry (pinned at top) when enabled.
 		const buildAssistantsGroup = (): HTMLOptGroupElement => {
-			const group = document.createElement("optgroup");
+			const group = activeDocument.createElement("optgroup");
 			group.label = "Assistants";
 			// Built-in agent entry — pinned first
 			if (this.plugin.settings.obsidianAgentSettings?.enabled) {
-				const agentOpt = document.createElement("option");
+				const agentOpt = activeDocument.createElement("option");
 				agentOpt.value = "agent:obsidian";
 				agentOpt.text = "Obsidian Agent";
 				group.appendChild(agentOpt);
 			}
 			const assistants = this.plugin.assistantManager?.getAssistants() ?? [];
 			for (const assistant of assistants) {
-				const opt = document.createElement("option");
+				const opt = activeDocument.createElement("option");
 				opt.value = `assistant:${assistant.id}`;
 				opt.text = assistant.name;
 				group.appendChild(opt);
@@ -3942,7 +3942,7 @@ export class ChatContainer extends Component {
 						link.getAttribute("data-href") ??
 						link.getAttribute("href") ??
 						"";
-					this.plugin.app.workspace.openLinkText(
+					void this.plugin.app.workspace.openLinkText(
 						href,
 						sourcePath,
 						e.ctrlKey || e.metaKey
@@ -3972,14 +3972,14 @@ export class ChatContainer extends Component {
 		const WIKI_RE = /\[\[([^\]]+)\]\]/g;
 
 		const makeLink = (target: string): HTMLAnchorElement => {
-			const a = document.createElement("a");
+			const a = activeDocument.createElement("a");
 			a.className = "internal-link";
 			a.setAttribute("data-href", target);
 			a.setAttribute("href", target);
 			a.textContent = target;
 			a.addEventListener("click", (e: MouseEvent) => {
 				e.preventDefault();
-				this.plugin.app.workspace.openLinkText(
+				void this.plugin.app.workspace.openLinkText(
 					target,
 					sourcePath,
 					e.ctrlKey || e.metaKey
@@ -4003,7 +4003,7 @@ export class ChatContainer extends Component {
 		// Case 2: plain text nodes that still contain [[...]] patterns.
 		// (These can appear when the model outputs [[file]] without backticks
 		// but MarkdownRenderer left them as literal text for any reason.)
-		const walker = document.createTreeWalker(
+		const walker = activeDocument.createTreeWalker(
 			container,
 			NodeFilter.SHOW_TEXT,
 			{
@@ -4035,21 +4035,21 @@ export class ChatContainer extends Component {
 			if (!parent) continue;
 
 			const text = textNode.textContent ?? "";
-			const fragment = document.createDocumentFragment();
+			const fragment = activeDocument.createDocumentFragment();
 			let lastIndex = 0;
 			let m: RegExpExecArray | null;
 			WIKI_RE.lastIndex = 0;
 
 			while ((m = WIKI_RE.exec(text)) !== null) {
 				if (m.index > lastIndex) {
-					fragment.appendChild(document.createTextNode(text.slice(lastIndex, m.index)));
+					fragment.appendChild(activeDocument.createTextNode(text.slice(lastIndex, m.index)));
 				}
 				fragment.appendChild(makeLink(m[1]));
 				lastIndex = m.index + m[0].length;
 			}
 
 			if (lastIndex < text.length) {
-				fragment.appendChild(document.createTextNode(text.slice(lastIndex)));
+				fragment.appendChild(activeDocument.createTextNode(text.slice(lastIndex)));
 			}
 
 			parent.replaceChild(fragment, textNode);
@@ -4401,14 +4401,14 @@ export class ChatContainer extends Component {
 		if (!selected) return;
 
 		// Measure the rendered text width using a temporary off-screen span.
-		const ruler = document.createElement("span");
+		const ruler = activeDocument.createElement("span");
 		ruler.style.cssText =
 			"visibility:hidden;position:absolute;white-space:nowrap;pointer-events:none;";
 		ruler.style.font = window.getComputedStyle(select).font;
 		ruler.textContent = selected.text;
-		document.body.appendChild(ruler);
+		activeDocument.body.appendChild(ruler);
 		const textWidth = ruler.getBoundingClientRect().width;
-		document.body.removeChild(ruler);
+		activeDocument.body.removeChild(ruler);
 
 		// Left pad (~4px) + text + right pad + chevron room (~22px) = ~26px total.
 		// Add a small buffer so the text never clips.
@@ -4430,18 +4430,18 @@ export class ChatContainer extends Component {
 		}
 
 		// Rebuild — includes Obsidian Agent entry at top when enabled
-		const group = document.createElement("optgroup");
+		const group = activeDocument.createElement("optgroup");
 		group.label = "Assistants";
 		const agentEnabled = this.plugin.settings.obsidianAgentSettings?.enabled;
 		if (agentEnabled) {
-			const agentOpt = document.createElement("option");
+			const agentOpt = activeDocument.createElement("option");
 			agentOpt.value = "agent:obsidian";
 			agentOpt.text = "Obsidian Agent";
 			group.appendChild(agentOpt);
 		}
 		const assistants = this.plugin.assistantManager?.getAssistants() ?? [];
 		for (const assistant of assistants) {
-			const opt = document.createElement("option");
+			const opt = activeDocument.createElement("option");
 			opt.value = `assistant:${assistant.id}`;
 			opt.text = assistant.name;
 			group.appendChild(opt);
@@ -4750,7 +4750,7 @@ export class ChatContainer extends Component {
 				e.preventDefault();
 				const file = this.plugin.app.vault.getAbstractFileByPath(path);
 				if (file) {
-					this.plugin.app.workspace.getLeaf(false).openFile(file as import("obsidian").TFile);
+					void this.plugin.app.workspace.getLeaf(false).openFile(file as import("obsidian").TFile);
 				}
 			});
 		}

--- a/src/Plugin/Components/ChatContainer.ts
+++ b/src/Plugin/Components/ChatContainer.ts
@@ -485,7 +485,7 @@ export class ChatContainer extends Component {
 			modelType,
 			modelName,
 		} = getViewInfo(this.plugin, this.viewType);
-		let shouldHaveAPIKey = modelType !== GPT4All && modelType !== ollama && modelType !== lmStudio && modelType !== mistral && modelEndpoint !== claudeCodeEndpoint;
+		const shouldHaveAPIKey = modelType !== GPT4All && modelType !== ollama && modelType !== lmStudio && modelType !== mistral && modelEndpoint !== claudeCodeEndpoint;
 		if (shouldHaveAPIKey) {
 			let API_KEY: string | undefined;
 			if (modelType === openAI) API_KEY = this.plugin.settings.openAIAPIKey;
@@ -1100,7 +1100,7 @@ export class ChatContainer extends Component {
 						(this.pendingContextString ? "\n\n---\n\n" + this.pendingContextString : "");
 				}
 			} catch (err) {
-				console.error("[LLM] Error reading local context paths:", err);
+				logger.error("[LLM] Error reading local context paths:", err);
 			}
 		}
 
@@ -3056,7 +3056,7 @@ export class ChatContainer extends Component {
 
 			// Open native OS file/folder picker via Electron
 			try {
-				const { remote } = require("electron") as any;
+				const { remote } = require("electron");
 				const nodePath = require("path") as typeof import("path");
 				const lastDir = (this.plugin.settings as any).lastLocalPickerDirectory || undefined;
 				remote.dialog.showOpenDialog({
@@ -3080,10 +3080,10 @@ export class ChatContainer extends Component {
 					this.localContextPaths.push({ label, absPath, isDir });
 					this.syncChips();
 				}).catch((err: Error) => {
-					console.error("[LLM] File picker error:", err);
+					logger.error("[LLM] File picker error:", err);
 				});
 			} catch (err) {
-				console.error("[LLM] Electron dialog unavailable:", err);
+				logger.error("[LLM] Electron dialog unavailable:", err);
 			}
 		};
 

--- a/src/Plugin/Components/Header.ts
+++ b/src/Plugin/Components/Header.ts
@@ -210,7 +210,7 @@ export class Header {
 						const historyFilePath = this.plugin.settings.fabSettings.historyFilePath;
 						this.plugin.pendingWidgetHistoryIndex = historyIndex;
 						this.plugin.pendingWidgetFilePath = historyFilePath;
-						this.plugin.activateSidebar();
+						void this.plugin.activateSidebar();
 						closeCallback?.();
 					});
 			});
@@ -223,7 +223,7 @@ export class Header {
 						const historyFilePath = this.plugin.settings.fabSettings.historyFilePath;
 						this.plugin.pendingWidgetHistoryIndex = historyIndex;
 						this.plugin.pendingWidgetFilePath = historyFilePath;
-						this.plugin.activateTab();
+						void this.plugin.activateTab();
 						closeCallback?.();
 					});
 			});
@@ -339,7 +339,7 @@ export class Header {
 		this.settingsButton.setTooltip("Chat settings");
 		this.settingsButton.onClick(() => {
 			settingsContainer.resetSettings(settingsContainerDiv);
-			settingsContainer.generateSettingsContainer(settingsContainerDiv);
+			void settingsContainer.generateSettingsContainer(settingsContainerDiv);
 			this.clickHandler(this.settingsButton!, [this.chatHistoryButton!]);
 			if (!settingsContainerDiv.isShown()) {
 				settingsContainerDiv.show();
@@ -527,7 +527,7 @@ export class Header {
 		this.settingsButton.setTooltip("Chat settings");
 		this.settingsButton.onClick(() => {
 			settingsContainer.resetSettings(settingsContainerDiv);
-			settingsContainer.generateSettingsContainer(settingsContainerDiv);
+			void settingsContainer.generateSettingsContainer(settingsContainerDiv);
 			this.clickHandler(this.settingsButton!, [this.chatHistoryButton]);
 			if (!settingsContainerDiv.isShown()) {
 				settingsContainerDiv.show();

--- a/src/Plugin/Components/HistoryContainer.ts
+++ b/src/Plugin/Components/HistoryContainer.ts
@@ -214,8 +214,8 @@ export class HistoryContainer {
 
 			item.addEventListener("mouseenter", () => {
 				if (
-					text.contentEditable == "false" ||
-					text.contentEditable == "inherit"
+					text.contentEditable === "false" ||
+					text.contentEditable === "inherit"
 				) {
 					editPrompt.buttonEl.setAttr("style", "visibility: visible");
 					deleteHistory.buttonEl.setAttr(
@@ -226,8 +226,8 @@ export class HistoryContainer {
 			});
 			item.addEventListener("mouseleave", () => {
 				if (
-					text.contentEditable == "false" ||
-					text.contentEditable == "inherit"
+					text.contentEditable === "false" ||
+					text.contentEditable === "inherit"
 				) {
 					editPrompt.buttonEl.setAttr("style", "visibility: hidden");
 					deleteHistory.buttonEl.setAttr(
@@ -243,7 +243,7 @@ export class HistoryContainer {
 				e.stopPropagation();
 				new ConfirmDeleteModal(this.plugin.app, () => {
 					this.resetHistory(parentElement);
-					let updatedHistory = this.plugin.settings.promptHistory.filter(
+					const updatedHistory = this.plugin.settings.promptHistory.filter(
 						(_item, idx) => idx !== index
 					);
 					this.plugin.settings.promptHistory = updatedHistory;

--- a/src/Plugin/Components/HistoryContainer.ts
+++ b/src/Plugin/Components/HistoryContainer.ts
@@ -129,7 +129,7 @@ export class HistoryContainer {
 			containerToShow.show();
 			chat.setMessages(true);
 			const messages = chat.getMessages();
-			chat.generateIMLikeMessages(messages);
+			void chat.generateIMLikeMessages(messages);
 			containerToShow.querySelector(".messages-div")?.scroll(0, 9999);
 			const index = this.historyIndex;
 			this.plugin.settings.currentIndex = index;
@@ -374,7 +374,7 @@ export class HistoryContainer {
 
 						// Restore messages into the store
 						chat.messageStore.setMessages(messages);
-						chat.generateIMLikeMessages(messages);
+						void chat.generateIMLikeMessages(messages);
 
 						parentElement.hide();
 						containerToShow.show();

--- a/src/Plugin/Components/SingletonNotice.ts
+++ b/src/Plugin/Components/SingletonNotice.ts
@@ -11,7 +11,7 @@ export class SingletonNotice {
     SingletonNotice.activeNotice = new Notice(message, duration);
 
     // Clear the active notice reference after the duration
-    activeWindow.setTimeout(() => {
+    window.setTimeout(() => {
       SingletonNotice.activeNotice = null;
     }, duration);
   }

--- a/src/Plugin/Errors/errors.ts
+++ b/src/Plugin/Errors/errors.ts
@@ -44,7 +44,7 @@ export function errorMessages(error: Error, params?: object) {
     }
 
     if(error.message.includes("SDK installation failed")) {
-        new Notice("Claude Code requires a one-time download of the runtime SDK (~69 MB). Please ensure npm is installed and you have an internet connection, then try again.")
+        new Notice("Claude Code runtime SDK installation failed. Use the 'Download SDK' button in Settings → Anthropic → Claude Code to install it.", 10000);
     }
 
     if ((error as { status?: number }).status === 429 || error.message.includes("Rate limit exceeded")) {

--- a/src/Plugin/FAB/FAB.ts
+++ b/src/Plugin/FAB/FAB.ts
@@ -153,7 +153,7 @@ export class FAB {
 			classNames["floating-action-button"]["title-border"];
 		chatContainerDiv.addClass("fab-chat-container", "llm-flex");
 
-		chatContainer.generateChatContainer(chatContainerDiv, header);
+		void chatContainer.generateChatContainer(chatContainerDiv, header);
 		historyContainer.generateHistoryContainer(
 			chatHistoryContainer,
 			history,
@@ -161,7 +161,7 @@ export class FAB {
 			chatContainer,
 			header
 		);
-		settingsContainer.generateSettingsContainer(settingsContainerDiv);
+		void settingsContainer.generateSettingsContainer(settingsContainerDiv);
 
 		const button = new ButtonComponent(fabContainer);
 		button
@@ -264,7 +264,7 @@ export class FAB {
 				this.chatContainer!.setSkillsByTurn(skillsByTurn);
 				this.chatContainer!.setModelsByTurn(modelsByTurn);
 				this.chatContainer!.messageStore.setMessages(messages);
-				this.chatContainer!.generateIMLikeMessages(messages);
+				void this.chatContainer!.generateIMLikeMessages(messages);
 
 				this.fabChatHistoryContainer!.hide();
 				this.fabChatContainerDiv!.show();

--- a/src/Plugin/FAB/FAB.ts
+++ b/src/Plugin/FAB/FAB.ts
@@ -143,7 +143,7 @@ export class FAB {
 			resizeHandle.addEventListener("pointerup", onPointerUp);
 		});
 
-		let history = this.plugin.settings.promptHistory;
+		const history = this.plugin.settings.promptHistory;
 
 		settingsContainerDiv.hide();
 		settingsContainerDiv.addClass("fab-settings-container", "llm-flex");
@@ -163,7 +163,7 @@ export class FAB {
 		);
 		settingsContainer.generateSettingsContainer(settingsContainerDiv);
 
-		let button = new ButtonComponent(fabContainer);
+		const button = new ButtonComponent(fabContainer);
 		button
 			.setIcon("bot-message-square")
 			.setClass("buttonItem")

--- a/src/Plugin/Modal/ChatModal2.ts
+++ b/src/Plugin/Modal/ChatModal2.ts
@@ -54,7 +54,7 @@ export class ChatModal2 extends Modal {
 			historyContainer,
 			settingsContainer
 		);
-		let history = this.plugin.settings.promptHistory;
+		const history = this.plugin.settings.promptHistory;
 
 		settingsContainerDiv.hide();
 		settingsContainerDiv.addClass("llm-modal-settings-container", "llm-flex");

--- a/src/Plugin/Modal/ChatModal2.ts
+++ b/src/Plugin/Modal/ChatModal2.ts
@@ -63,7 +63,7 @@ export class ChatModal2 extends Modal {
 		lineBreak.className = classNames["modal"]["title-border"];
 		chatContainerDiv.addClass("llm-modal-chat-container", "llm-flex");
 
-		chatContainer.generateChatContainer(chatContainerDiv, header);
+		void chatContainer.generateChatContainer(chatContainerDiv, header);
 		historyContainer.generateHistoryContainer(
 			chatHistoryContainer,
 			history,
@@ -71,7 +71,7 @@ export class ChatModal2 extends Modal {
 			chatContainer,
 			header
 		);
-		settingsContainer.generateSettingsContainer(settingsContainerDiv);
+		void settingsContainer.generateSettingsContainer(settingsContainerDiv);
 	}
 
 	onClose() {

--- a/src/Plugin/StatusBar/RecentChatsButton.ts
+++ b/src/Plugin/StatusBar/RecentChatsButton.ts
@@ -24,7 +24,7 @@ export class RecentChatsButton {
 		iconEl.addClass("llm-status-bar-icon");
 		setIcon(iconEl, "clock");
 
-		this.popoverEl = document.body.createDiv();
+		this.popoverEl = activeDocument.body.createDiv();
 		this.popoverEl.addClass("llm-recent-chats-popover");
 		this.popoverEl.addClass("llm-hidden");
 
@@ -255,9 +255,9 @@ export class RecentChatsButton {
 					this.hidePopover();
 				}
 			};
-			activeWindow.setTimeout(() => {
-				document.addEventListener("click", this.clickOutsideHandler!);
-				document.addEventListener("keydown", this.keydownHandler!);
+			window.setTimeout(() => {
+				activeDocument.addEventListener("click", this.clickOutsideHandler!);
+				activeDocument.addEventListener("keydown", this.keydownHandler!);
 			}, 0);
 		} else {
 			this.hidePopover();
@@ -267,11 +267,11 @@ export class RecentChatsButton {
 	private hidePopover() {
 		if (this.popoverEl) this.popoverEl.addClass("llm-hidden");
 		if (this.clickOutsideHandler) {
-			document.removeEventListener("click", this.clickOutsideHandler);
+			activeDocument.removeEventListener("click", this.clickOutsideHandler);
 			this.clickOutsideHandler = null;
 		}
 		if (this.keydownHandler) {
-			document.removeEventListener("keydown", this.keydownHandler);
+			activeDocument.removeEventListener("keydown", this.keydownHandler);
 			this.keydownHandler = null;
 		}
 	}

--- a/src/Plugin/StatusBar/StatusBarButton.ts
+++ b/src/Plugin/StatusBar/StatusBarButton.ts
@@ -84,7 +84,7 @@ export class StatusBarButton {
 	}
 
 	private buildPopover() {
-		this.popoverEl = document.body.createDiv();
+		this.popoverEl = activeDocument.body.createDiv();
 		this.popoverEl.addClass("llm-status-bar-popover");
 		this.popoverEl.addClass("llm-hidden");
 
@@ -155,7 +155,7 @@ export class StatusBarButton {
 		chatContainerDiv.addClass("fab-chat-container", "llm-flex");
 
 		const history = this.plugin.settings.promptHistory;
-		this.chatContainer.generateChatContainer(chatContainerDiv, this.header);
+		void this.chatContainer.generateChatContainer(chatContainerDiv, this.header);
 		historyContainer.generateHistoryContainer(
 			chatHistoryContainer,
 			history,
@@ -163,7 +163,7 @@ export class StatusBarButton {
 			this.chatContainer,
 			this.header
 		);
-		settingsContainer.generateSettingsContainer(settingsContainerDiv);
+		void settingsContainer.generateSettingsContainer(settingsContainerDiv);
 
 		// Resize handle — same logic as FAB, but repositions after each drag
 		// so the popover stays anchored above the status bar.
@@ -333,7 +333,7 @@ export class StatusBarButton {
 		this.chatContainerDiv.show();
 		this.chatContainer.setMessages(true);
 		const messages = this.chatContainer.getMessages();
-		this.chatContainer.generateIMLikeMessages(messages);
+		void this.chatContainer.generateIMLikeMessages(messages);
 		this.chatContainerDiv.querySelector(".messages-div")?.scroll(0, 9999);
 		this.header?.setHeader(historyItem?.modelName ?? "");
 		this.header?.resetHistoryButton();
@@ -381,7 +381,7 @@ export class StatusBarButton {
 				this.chatContainer!.setSkillsByTurn(skillsByTurn);
 				this.chatContainer!.setModelsByTurn(modelsByTurn);
 				this.chatContainer!.messageStore.setMessages(messages);
-				this.chatContainer!.generateIMLikeMessages(messages);
+				void this.chatContainer!.generateIMLikeMessages(messages);
 
 				this.chatHistoryContainer!.hide();
 				this.chatContainerDiv!.show();

--- a/src/Plugin/Widget/Widget.ts
+++ b/src/Plugin/Widget/Widget.ts
@@ -72,7 +72,7 @@ export class WidgetView extends ItemView {
 		const messages = this.chatContainer.getMessages();
 		if (messages.length > 0) {
 			this.chatContainer.resetChat();
-			this.chatContainer.generateIMLikeMessages(messages);
+			void this.chatContainer.generateIMLikeMessages(messages);
 		}
 
 		// Sync header state
@@ -98,7 +98,7 @@ export class WidgetView extends ItemView {
 			this.chatContainer.setSkillsByTurn(skillsByTurn);
 			this.chatContainer.setModelsByTurn(modelsByTurn);
 			this.chatContainer.messageStore.setMessages(messages);
-			this.chatContainer.generateIMLikeMessages(messages);
+			void this.chatContainer.generateIMLikeMessages(messages);
 
 			if (this.chatContainerDiv) this.chatContainerDiv.show();
 			if (this.chatHistoryContainer) this.chatHistoryContainer.hide();
@@ -242,7 +242,7 @@ export class WidgetView extends ItemView {
 			historyContainer,
 			settingsContainer
 		);
-		chatContainer.generateChatContainer(chatContainerDiv, header);
+		void chatContainer.generateChatContainer(chatContainerDiv, header);
 		// generateChatContainer is async; schedule an initial sidebar state push
 		// so the inline sidebar has content the first time the user opens it,
 		// even if no other action (chip sync, model change) has fired yet.
@@ -254,7 +254,7 @@ export class WidgetView extends ItemView {
 			chatContainer,
 			header
 		);
-		settingsContainer.generateSettingsContainer(settingsContainerDiv);
+		void settingsContainer.generateSettingsContainer(settingsContainerDiv);
 
 		// Auto-load a conversation if one was pending (set by "Open in sidebar/tab" from the FAB).
 		const pendingIndex = this.plugin.pendingWidgetHistoryIndex;

--- a/src/Projects/ProjectManager.ts
+++ b/src/Projects/ProjectManager.ts
@@ -193,7 +193,7 @@ created: ${created}
 		try {
 			const file = this.app.vault.getFileByPath(project.filePath);
 			if (file) {
-				await this.app.vault.trash(file, true);
+				await this.app.fileManager.trashFile(file);
 			}
 			this.projects.delete(id);
 		} catch (e) {

--- a/src/RAG/EmbeddingService.ts
+++ b/src/RAG/EmbeddingService.ts
@@ -1,6 +1,7 @@
 import OpenAI from "openai";
 import { logger } from "../utils/logger";
 import { GoogleGenAI } from "@google/genai";
+import { requestUrl } from "obsidian";
 
 export type EmbeddingProvider = "onnx" | "openai" | "gemini" | "ollama" | "lmStudio";
 
@@ -381,9 +382,9 @@ export class EmbeddingService {
 		const host  = this.config.ollamaHost ?? "http://localhost:11434";
 		const model = this.config.model ?? DEFAULT_EMBEDDING_MODELS["ollama"];
 		try {
-			const res = await fetch(`${host}/api/tags`);
-			if (!res.ok) return false;
-			const data = await res.json();
+			const res = await requestUrl({ url: `${host}/api/tags`, throw: false });
+			if (res.status >= 400) return false;
+			const data = res.json;
 			const pulled    = (data.models ?? []).map((m: any) => m.name.split(":")[0]);
 			const modelBase = model.split(":")[0];
 			if (!pulled.includes(modelBase)) throw new OllamaModelNotFoundError(model, host);

--- a/src/Settings/LLMSettingsModal.ts
+++ b/src/Settings/LLMSettingsModal.ts
@@ -594,6 +594,7 @@ export class LLMSettingsModal extends Modal {
 
 		// ── Guidance (AGENTS.md) — declared early so the rootVaultFolder onChange
 		// closure can re-render it when the path is auto-updated.
+		// eslint-disable-next-line prefer-const
 		let agentsGroup: HTMLElement;
 
 		const renderAgentsPicker = () => {
@@ -900,7 +901,7 @@ export class LLMSettingsModal extends Modal {
 
 		// Claude Code
 		const authItems = this.addSettingGroup(el, "Claude Code");
-		const oauthSetting = new Setting(authItems)
+		new Setting(authItems)
 			.setName("Claude Code OAuth token")
 			.setDesc("OAuth token for authenticating with Claude Code (CLAUDE_CODE_OAUTH_TOKEN).")
 			.addText((text) => {

--- a/src/Settings/LLMSettingsModal.ts
+++ b/src/Settings/LLMSettingsModal.ts
@@ -18,6 +18,7 @@ import { FAB } from "Plugin/FAB/FAB";
 import { ChatModal2 } from "Plugin/Modal/ChatModal2";
 import { EmbeddingService, EmbeddingProvider, DEFAULT_EMBEDDING_MODELS } from "RAG/EmbeddingService";
 import { ALL_TOOL_DEFINITIONS } from "services/ObsidianToolRegistry";
+import { ensureSDKInstalled, isSDKInstalled } from "services/ClaudeAgentSDKInstaller";
 
 type APIKeyType = "claude" | "gemini" | "openai" | "mistral";
 
@@ -967,6 +968,38 @@ export class LLMSettingsModal extends Modal {
 				}
 			});
 		});
+
+		// Runtime SDK install
+		const vaultBasePath = (this.plugin.app.vault.adapter as any).getBasePath?.() ?? "";
+		const pluginDir = require("path").join(vaultBasePath, this.plugin.manifest.dir);
+		const sdkAlreadyInstalled = isSDKInstalled(pluginDir);
+		const sdkInstallSetting = new Setting(authItems)
+			.setName("Runtime SDK")
+			.setDesc(sdkAlreadyInstalled
+				? "Claude Code runtime SDK is installed."
+				: "The Claude Code runtime SDK (~69 MB) must be downloaded before use. Requires npm and an internet connection.");
+		let sdkStatusEl: HTMLElement | null = null;
+		if (!sdkAlreadyInstalled) {
+			sdkInstallSetting.addButton((btn) => {
+				btn.setButtonText("Download SDK");
+				btn.onClick(async () => {
+					if (sdkStatusEl) sdkStatusEl.remove();
+					sdkStatusEl = sdkInstallSetting.descEl.createDiv({ cls: "llm-api-test-status llm-api-test-running", text: "Downloading (~69 MB)…" });
+					btn.setDisabled(true);
+					try {
+						await ensureSDKInstalled(pluginDir);
+						sdkStatusEl.className = "llm-api-test-status llm-api-test-ok";
+						sdkStatusEl.setText("✓ Runtime SDK installed.");
+						sdkInstallSetting.setDesc("Claude Code runtime SDK is installed.");
+						btn.buttonEl.remove();
+					} catch (e: any) {
+						sdkStatusEl.className = "llm-api-test-status llm-api-test-fail";
+						sdkStatusEl.setText(`✗ ${e.message ?? "Installation failed"}`);
+						btn.setDisabled(false);
+					}
+				});
+			});
+		}
 	}
 
 	private renderConnectors() {

--- a/src/Settings/LLMSettingsModal.ts
+++ b/src/Settings/LLMSettingsModal.ts
@@ -152,8 +152,8 @@ export class LLMSettingsModal extends Modal {
 		const appSetting = (this.app as any).setting;
 		this.coreModalEl =
 			appSetting?.containerEl?.closest?.(".modal") ??
-			document.querySelector<HTMLElement>(".modal-container.mod-settings .modal") ??
-			Array.from(document.querySelectorAll<HTMLElement>(".modal-container .modal"))
+			activeDocument.querySelector<HTMLElement>(".modal-container.mod-settings .modal") ??
+			Array.from(activeDocument.querySelectorAll<HTMLElement>(".modal-container .modal"))
 				.find((el) => el !== modalEl && !el.contains(modalEl)) ??
 			null;
 
@@ -174,8 +174,8 @@ export class LLMSettingsModal extends Modal {
 				this.close();
 			}
 		};
-		activeWindow.setTimeout(() => {
-			document.addEventListener("mousedown", this.outsideClickHandler!);
+		window.setTimeout(() => {
+			activeDocument.addEventListener("mousedown", this.outsideClickHandler!);
 		}, 0);
 
 		// mod-sidebar-layout tells Obsidian's CSS to apply the two-column layout.
@@ -201,7 +201,7 @@ export class LLMSettingsModal extends Modal {
 			this.resizeHandler = null;
 		}
 		if (this.outsideClickHandler) {
-			document.removeEventListener("mousedown", this.outsideClickHandler);
+			activeDocument.removeEventListener("mousedown", this.outsideClickHandler);
 			this.outsideClickHandler = null;
 		}
 		this.contentEl.empty();
@@ -304,12 +304,12 @@ export class LLMSettingsModal extends Modal {
 				const allModelNames = { ...modelNames, ...ollamaBuilt.names, ...lmStudioBuilt.names };
 
 				// ── Models optgroup ───────────────────────────────────────────
-				const modelsGroup = document.createElement("optgroup");
+				const modelsGroup = activeDocument.createElement("optgroup");
 				modelsGroup.label = "Models";
 				for (const model of Object.keys(allModels)) {
 					const type = allModels[model].type;
 					if (type === ollama || type === lmStudio) {
-						const opt = document.createElement("option");
+						const opt = activeDocument.createElement("option");
 						opt.value = allModels[model].model;
 						opt.text = model;
 						modelsGroup.appendChild(opt);
@@ -318,14 +318,14 @@ export class LLMSettingsModal extends Modal {
 					if (type === GPT4All) {
 						const fullPath = `${getGpt4AllPath(this.plugin)}/${allModels[model].model}`;
 						if (this.plugin.fileSystem.existsSync(fullPath)) {
-							const opt = document.createElement("option");
+							const opt = activeDocument.createElement("option");
 							opt.value = allModels[model].model;
 							opt.text = model;
 							modelsGroup.appendChild(opt);
 						}
 						continue;
 					}
-					const opt = document.createElement("option");
+					const opt = activeDocument.createElement("option");
 					opt.value = allModels[model].model;
 					opt.text = model;
 					modelsGroup.appendChild(opt);
@@ -336,17 +336,17 @@ export class LLMSettingsModal extends Modal {
 				const assistants = this.plugin.assistantManager?.getAssistants() ?? [];
 				const agentEnabled = this.plugin.settings.obsidianAgentSettings?.enabled;
 				if (agentEnabled || assistants.length > 0) {
-					const assistantsGroup = document.createElement("optgroup");
+					const assistantsGroup = activeDocument.createElement("optgroup");
 					assistantsGroup.label = "Assistants";
 					// Obsidian Agent pinned first, only when the feature is enabled
 					if (agentEnabled) {
-						const agentOpt = document.createElement("option");
+						const agentOpt = activeDocument.createElement("option");
 						agentOpt.value = "agent:obsidian";
 						agentOpt.text = "Obsidian Agent";
 						assistantsGroup.appendChild(agentOpt);
 					}
 					for (const assistant of assistants) {
-						const opt = document.createElement("option");
+						const opt = activeDocument.createElement("option");
 						opt.value = `assistant:${assistant.id}`;
 						opt.text = assistant.name;
 						assistantsGroup.appendChild(opt);
@@ -758,7 +758,7 @@ export class LLMSettingsModal extends Modal {
 					if (!correct && this.plugin.settings.useSpecialAnimation) {
 						this.plugin.settings.useSpecialAnimation = false;
 						toggleComponent.setValue(false);
-						this.plugin.saveSettings();
+						void this.plugin.saveSettings();
 					}
 				});
 			})
@@ -823,7 +823,7 @@ export class LLMSettingsModal extends Modal {
 				}
 				// Render the editor as an overlay inside the parent modal's own box
 				// (modalEl) — avoids triggering the parent modal's close handlers.
-				new GuidanceEditorOverlay(this.plugin, this.modalEl, path, template).open();
+				void new GuidanceEditorOverlay(this.plugin, this.modalEl, path, template).open();
 			});
 		});
 	}
@@ -1273,7 +1273,7 @@ export class LLMSettingsModal extends Modal {
 					.setDesc("Clears the old in-settings chat history only. Your saved markdown chat files in your vault are not affected.")
 					.addButton((button: ButtonComponent) => {
 						button.setButtonText("Reset history");
-						button.setWarning();
+						button.setDestructive();
 						button.onClick(() => {
 							this.plugin.history.reset();
 						});
@@ -1391,13 +1391,13 @@ export class LLMSettingsModal extends Modal {
 			const setting = new Setting(toolsItems);
 
 			// Build the name element: risk badge + display name
-			const nameFragment = document.createDocumentFragment();
+			const nameFragment = activeDocument.createDocumentFragment();
 			const badge = nameFragment.createEl("span", {
 				cls: `llm-tool-badge llm-tool-badge-${tool.risk}`,
 				text: tool.risk,
 			});
 			nameFragment.appendChild(badge);
-			nameFragment.appendChild(document.createTextNode(" " + tool.displayName));
+			nameFragment.appendChild(activeDocument.createTextNode(" " + tool.displayName));
 			setting.nameEl.appendChild(nameFragment);
 
 			// Description: tool description + optional dependency notes
@@ -1659,7 +1659,7 @@ export class LLMSettingsModal extends Modal {
 			});
 			// Registry may not have loaded yet (onLayoutReady race). Reload once and
 			// re-render only if skills are actually found, to avoid a flash loop.
-			this.plugin.skillRegistry?.reloadAll().then(() => {
+			void this.plugin.skillRegistry?.reloadAll().then(() => {
 				if (
 					this.activeTab === "skills" &&
 					(this.plugin.skillRegistry?.getSkills().length ?? 0) > 0
@@ -1831,7 +1831,7 @@ export class LLMSettingsModal extends Modal {
 						if (filePath) {
 							new Notice(`✓ Project "${name}" created.`);
 							this.renderTab("projects");
-							new GuidanceEditorOverlay(this.plugin, this.modalEl, filePath, "").open();
+							void new GuidanceEditorOverlay(this.plugin, this.modalEl, filePath, "").open();
 						} else {
 							new Notice("Failed to create project.");
 						}
@@ -1860,7 +1860,7 @@ export class LLMSettingsModal extends Modal {
 				btn.setIcon("pencil")
 					.setTooltip("Edit PROJECT.md")
 					.onClick(() => {
-						new GuidanceEditorOverlay(this.plugin, this.modalEl, project.filePath, "").open();
+						void new GuidanceEditorOverlay(this.plugin, this.modalEl, project.filePath, "").open();
 					});
 			});
 
@@ -1868,7 +1868,7 @@ export class LLMSettingsModal extends Modal {
 			setting.addButton((btn) => {
 				btn.setIcon("trash")
 					.setTooltip("Delete project")
-					.setWarning()
+					.setDestructive()
 					.onClick(async () => {
 						await this.plugin.projectManager.deleteProject(project.id);
 						new Notice(`Project "${project.name}" deleted.`);
@@ -1970,7 +1970,7 @@ export class LLMSettingsModal extends Modal {
 				btn.setIcon("pencil")
 					.setTooltip("Edit ASSISTANT.md")
 					.onClick(() => {
-						new GuidanceEditorOverlay(this.plugin, this.modalEl, assistant.filePath, "").open();
+						void new GuidanceEditorOverlay(this.plugin, this.modalEl, assistant.filePath, "").open();
 					});
 			});
 
@@ -1978,7 +1978,7 @@ export class LLMSettingsModal extends Modal {
 			setting.addButton((btn) => {
 				btn.setIcon("trash")
 					.setTooltip("Delete assistant")
-					.setWarning()
+					.setDestructive()
 					.onClick(async () => {
 						await this.plugin.assistantManager.deleteAssistant(assistant.id);
 						new Notice(`Assistant "${assistant.name}" deleted.`);
@@ -2419,7 +2419,7 @@ export class LLMSettingsModal extends Modal {
 						serverBtn.setButtonText("Stop server");
 						serverBtn.onClick(async () => {
 							this.plugin.sidecarManager.stopServer();
-							await new Promise((r) => activeWindow.setTimeout(r, 800));
+							await new Promise((r) => window.setTimeout(r, 800));
 							await refreshStatus();
 						});
 					} else {
@@ -2435,7 +2435,7 @@ export class LLMSettingsModal extends Modal {
 							// Give the server 2 s to spin up then re-check
 							serverBtn!.setButtonText("Starting…");
 							serverBtn!.setDisabled(true);
-							await new Promise((r) => activeWindow.setTimeout(r, 2500));
+							await new Promise((r) => window.setTimeout(r, 2500));
 							await refreshStatus();
 						});
 					}
@@ -2451,7 +2451,7 @@ export class LLMSettingsModal extends Modal {
 			this.registerSidecarPollCleanup(stopPolling);
 
 			// Kick off the initial check
-			refreshStatus();
+			void refreshStatus();
 		}
 
 		// ── Test Connection ──────────────────────────────────────────────────
@@ -2748,7 +2748,7 @@ class ShellCommandWarningModal extends Modal {
 			.onClick(() => this.close());
 		new ButtonComponent(btnRow)
 			.setButtonText("Yes, enable shell commands")
-			.setWarning()
+			.setDestructive()
 			.onClick(() => {
 				this.close();
 				this.onConfirm();

--- a/src/Whisper/TranscribeCommand.ts
+++ b/src/Whisper/TranscribeCommand.ts
@@ -145,7 +145,7 @@ async function buildUniqueNotePath(
 	baseFilename: string,
 ): Promise<string> {
 	const adapter = plugin.app.vault.adapter;
-	let candidate = `${folder}/${baseFilename}.md`;
+	const candidate = `${folder}/${baseFilename}.md`;
 	if (!(await adapter.exists(candidate))) return candidate;
 
 	let i = 2;

--- a/src/Whisper/WhisperService.ts
+++ b/src/Whisper/WhisperService.ts
@@ -191,7 +191,7 @@ export class WhisperService {
 		// 60-second timeout — large files on slow hardware can take a while,
 		// but we never want to hang indefinitely if the server is unresponsive.
 		const controller = new AbortController();
-		const timeout = activeWindow.setTimeout(() => controller.abort(), 60_000);
+		const timeout = window.setTimeout(() => controller.abort(), 60_000);
 
 		let response: Response;
 		try {
@@ -213,7 +213,7 @@ export class WhisperService {
 				{ cause: err },
 			);
 		} finally {
-			activeWindow.clearTimeout(timeout);
+			window.clearTimeout(timeout);
 		}
 
 		if (!response.ok) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -470,12 +470,12 @@ export default class LLMPlugin extends Plugin {
 		this.recentChatsButton = new RecentChatsButton(this, this.statusBarButton);
 		this.addSettingTab(new SettingsView(this.app, this, this.fab));
 		if (this.settings.showFAB) {
-			activeWindow.setTimeout(() => {
+			window.setTimeout(() => {
 				this.fab.regenerateFAB();
 			}, 500);
 		}
 		if (this.settings.showStatusBarButton) {
-			activeWindow.setTimeout(() => {
+			window.setTimeout(() => {
 				this.statusBarButton.generate();
 				this.recentChatsButton.generate();
 			}, 500);
@@ -543,7 +543,7 @@ export default class LLMPlugin extends Plugin {
 						// The user clicked the button in a specific tab — the natural expectation
 						// is that THAT tab becomes the chat widget, not some other open tab.
 						await leaf.setViewState({ type: TAB_VIEW_TYPE, active: true });
-						this.app.workspace.revealLeaf(leaf);
+						void this.app.workspace.revealLeaf(leaf);
 						// leaf.view is now a WidgetView; load the chat file directly.
 						await (leaf.view as WidgetView).loadChatFile(path);
 					}
@@ -616,19 +616,20 @@ export default class LLMPlugin extends Plugin {
 			if (this.lastFocusedWidgetLeaf && tabs.includes(this.lastFocusedWidgetLeaf)) {
 				leaf = this.lastFocusedWidgetLeaf;
 			} else {
-				const activeLeaf = workspace.activeLeaf;
-				leaf = (activeLeaf && activeLeaf.view instanceof WidgetView && tabs.includes(activeLeaf))
+				const activeWidgetView = workspace.getActiveViewOfType(WidgetView);
+				const activeLeaf = activeWidgetView?.leaf;
+				leaf = (activeLeaf && tabs.includes(activeLeaf))
 					? activeLeaf
 					: tabs[0];
 			}
-			workspace.revealLeaf(leaf);
+			void workspace.revealLeaf(leaf);
 			await (leaf.view as WidgetView).loadChatFile(filePath);
 		} else {
 			// No widget open — set pending path and open a new tab; onOpen() will load it
 			this.pendingWidgetFilePath = filePath;
 			const leaf = workspace.getLeaf("tab");
 			await leaf.setViewState({ type: TAB_VIEW_TYPE, active: true });
-			workspace.revealLeaf(leaf);
+			void workspace.revealLeaf(leaf);
 		}
 	}
 
@@ -663,9 +664,9 @@ export default class LLMPlugin extends Plugin {
 
 				const path = file.path;
 				const existing = this.ragDebounceTimers.get(path);
-				if (existing) activeWindow.clearTimeout(existing);
+				if (existing) window.clearTimeout(existing);
 
-				const timer = activeWindow.setTimeout(async () => {
+				const timer = window.setTimeout(async () => {
 					this.ragDebounceTimers.delete(path);
 					try {
 						await this.vaultIndexer!.indexFile(file);
@@ -691,7 +692,7 @@ export default class LLMPlugin extends Plugin {
 				// Cancel any pending reindex for this file
 				const timer = this.ragDebounceTimers.get(file.path);
 				if (timer) {
-					activeWindow.clearTimeout(timer);
+					window.clearTimeout(timer);
 					this.ragDebounceTimers.delete(file.path);
 				}
 
@@ -1034,7 +1035,7 @@ export default class LLMPlugin extends Plugin {
 		// Cancel any pending RAG debounce timers so they don't fire after the
 		// plugin is torn down and try to write to a null vaultIndexer.
 		for (const timer of this.ragDebounceTimers.values()) {
-			activeWindow.clearTimeout(timer);
+			window.clearTimeout(timer);
 		}
 		this.ragDebounceTimers.clear();
 
@@ -1059,7 +1060,7 @@ export default class LLMPlugin extends Plugin {
 			id: "open-LLM-widget-tab",
 			name: "Open chat in tab",
 			callback: () => {
-				this.activateTab();
+				void this.activateTab();
 			},
 		});
 
@@ -1069,7 +1070,7 @@ export default class LLMPlugin extends Plugin {
 			callback: async () => {
 				const leaf = this.app.workspace.getLeaf("tab");
 				await leaf.setViewState({ type: TAB_VIEW_TYPE, active: true });
-				this.app.workspace.revealLeaf(leaf);
+				void this.app.workspace.revealLeaf(leaf);
 			},
 		});
 
@@ -1166,7 +1167,7 @@ export default class LLMPlugin extends Plugin {
 		const leaves = workspace.getLeavesOfType(CHAT_DETAILS_VIEW_TYPE);
 
 		if (leaves.length > 0) {
-			workspace.revealLeaf(leaves[0]);
+			void workspace.revealLeaf(leaves[0]);
 			(leaves[0].view as ChatDetailsView).refreshFromPlugin();
 			return;
 		}
@@ -1174,7 +1175,7 @@ export default class LLMPlugin extends Plugin {
 		const leaf = workspace.getRightLeaf(false);
 		if (!leaf) return;
 		await leaf.setViewState({ type: CHAT_DETAILS_VIEW_TYPE, active: true });
-		workspace.revealLeaf(leaf);
+		void workspace.revealLeaf(leaf);
 	}
 
 	/**
@@ -1203,7 +1204,7 @@ export default class LLMPlugin extends Plugin {
 			// Bring the Chat Details tab to front in case other panels are also open
 			const detailsLeaves = workspace.getLeavesOfType(CHAT_DETAILS_VIEW_TYPE);
 			if (detailsLeaves.length > 0) {
-				workspace.revealLeaf(detailsLeaves[0]);
+				void workspace.revealLeaf(detailsLeaves[0]);
 				(detailsLeaves[0].view as ChatDetailsView).refreshFromPlugin();
 			}
 			return true;
@@ -1231,7 +1232,7 @@ export default class LLMPlugin extends Plugin {
 		const leaves = workspace.getLeavesOfType(CHATS_VIEW_TYPE);
 
 		if (leaves.length > 0) {
-			workspace.revealLeaf(leaves[0]);
+			void workspace.revealLeaf(leaves[0]);
 			const view = leaves[0].view as ChatsView;
 			await view.refresh();
 			return;
@@ -1240,7 +1241,7 @@ export default class LLMPlugin extends Plugin {
 		const leaf = workspace.getLeftLeaf(false);
 		if (!leaf) return;
 		await leaf.setViewState({ type: CHATS_VIEW_TYPE, active: true });
-		workspace.revealLeaf(leaf);
+		void workspace.revealLeaf(leaf);
 	}
 
 	async activateTab() {
@@ -1269,7 +1270,7 @@ export default class LLMPlugin extends Plugin {
 			await tab.setViewState({ type: TAB_VIEW_TYPE, active: true });
 			// onOpen will handle auto-loading via pendingWidgetHistoryIndex / pendingWidgetFilePath.
 		}
-		workspace.revealLeaf(tab);
+		void workspace.revealLeaf(tab);
 	}
 
 	async activateSidebar() {
@@ -1299,7 +1300,7 @@ export default class LLMPlugin extends Plugin {
 			await leaf.setViewState({ type: TAB_VIEW_TYPE, active: true });
 			// onOpen will handle auto-loading via pendingWidgetHistoryIndex / pendingWidgetFilePath.
 		}
-		workspace.revealLeaf(leaf);
+		void workspace.revealLeaf(leaf);
 	}
 
 	async loadSettings() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -470,12 +470,12 @@ export default class LLMPlugin extends Plugin {
 		this.recentChatsButton = new RecentChatsButton(this, this.statusBarButton);
 		this.addSettingTab(new SettingsView(this.app, this, this.fab));
 		if (this.settings.showFAB) {
-			window.setTimeout(() => {
+			activeWindow.setTimeout(() => {
 				this.fab.regenerateFAB();
 			}, 500);
 		}
 		if (this.settings.showStatusBarButton) {
-			window.setTimeout(() => {
+			activeWindow.setTimeout(() => {
 				this.statusBarButton.generate();
 				this.recentChatsButton.generate();
 			}, 500);

--- a/src/main.ts
+++ b/src/main.ts
@@ -293,7 +293,7 @@ function mergeSettingsWithDefaults(
 	defaults: LLMPluginSettings,
 	saved: Record<string, unknown>,
 ): LLMPluginSettings {
-	const result = { ...defaults, ...saved } as LLMPluginSettings;
+	const result = { ...defaults, ...saved };
 	for (const key of Object.keys(defaults) as (keyof LLMPluginSettings)[]) {
 		const def = defaults[key];
 		const sav = saved[key];
@@ -307,7 +307,7 @@ function mergeSettingsWithDefaults(
 			if (nestedDef === null || typeof nestedDef !== "object" || Array.isArray(nestedDef)) continue;
 			(merged as Record<string, unknown>)[nestedKey] = {
 				...nestedDef,
-				...(nestedSav as object ?? {}),
+				...(nestedSav ?? {}),
 			};
 		}
 		(result as unknown as Record<string, unknown>)[key] = merged;
@@ -1374,7 +1374,7 @@ export default class LLMPlugin extends Plugin {
 			const oauth = data?.claudeAiOauth;
 			if (!oauth?.accessToken) return null;
 			if (oauth.expiresAt && Date.now() > oauth.expiresAt) {
-				console.warn("[LLM Plugin] Claude Code OAuth token is expired. Re-authenticate via `claude` in your terminal.");
+				logger.warn("[LLM Plugin] Claude Code OAuth token is expired. Re-authenticate via `claude` in your terminal.");
 				return null;
 			}
 			return oauth.accessToken as string;

--- a/src/services/ChatHistory.ts
+++ b/src/services/ChatHistory.ts
@@ -541,7 +541,7 @@ export class ChatHistory {
 	async delete(filePath: string): Promise<void> {
 		const file = this.plugin.app.vault.getFileByPath(filePath);
 		if (file) {
-			await this.plugin.app.vault.trash(file, true);
+			await this.plugin.app.fileManager.trashFile(file);
 			return;
 		}
 		// Fallback: bypass the file cache and remove directly via the adapter.

--- a/src/services/ClaudeAgentSDKInstaller.ts
+++ b/src/services/ClaudeAgentSDKInstaller.ts
@@ -154,20 +154,20 @@ function doInstall(pluginDir: string): Promise<void> {
 			stdio: ["ignore", "pipe", "pipe"],
 		});
 
-		const timeout = activeWindow.setTimeout(() => {
+		const timeout = window.setTimeout(() => {
 			child.kill();
 			notice.hide();
 			reject(new Error("SDK installation failed: timed out after 2 minutes"));
 		}, INSTALL_TIMEOUT_MS);
 
 		child.on("error", (err: Error) => {
-			activeWindow.clearTimeout(timeout);
+			window.clearTimeout(timeout);
 			notice.hide();
 			reject(new Error("SDK installation failed: " + err.message));
 		});
 
 		child.on("close", (code: number) => {
-			activeWindow.clearTimeout(timeout);
+			window.clearTimeout(timeout);
 			notice.hide();
 
 			if (code !== 0) {

--- a/src/services/ClaudeAgentSDKInstaller.ts
+++ b/src/services/ClaudeAgentSDKInstaller.ts
@@ -83,7 +83,7 @@ function resolveNpmPath(): string {
 	return bin;
 }
 
-function isSDKInstalled(pluginDir: string): boolean {
+export function isSDKInstalled(pluginDir: string): boolean {
 	if (!Platform.isDesktop) return false;
 	const fs = require("fs");
 	return fs.existsSync(getNativeBinaryPath(pluginDir));

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -295,47 +295,6 @@ export async function geminiMessage(
 	return stream;
 }
 
-// Resolve the absolute path to `node` by checking common install locations.
-// Electron's renderer process has a limited PATH, so we check the filesystem directly.
-function resolveNodePath(): string {
-	if (!Platform.isDesktop) return "";
-	const fs = require("fs");
-	const homedir = require("os").homedir();
-	const candidates: string[] = [];
-
-	// nvm — pick the latest installed version
-	const nvmDir = `${homedir}/.nvm/versions/node`;
-	try {
-		if (fs.existsSync(nvmDir)) {
-			const versions = fs.readdirSync(nvmDir).sort().reverse();
-			if (versions.length > 0) {
-				candidates.push(`${nvmDir}/${versions[0]}/bin/node`);
-			}
-		}
-	} catch { /* ignore */ }
-
-	candidates.push(
-		`${homedir}/.volta/bin/node`,                       // volta
-		`${homedir}/.local/share/fnm/aliases/default/bin/node`, // fnm
-		`${homedir}/.asdf/shims/node`,                      // asdf
-		`${homedir}/.local/bin/node`,
-		"/usr/local/bin/node",
-		"/usr/bin/node",
-		"/snap/bin/node",
-	);
-
-	for (const candidate of candidates) {
-		try {
-			if (fs.existsSync(candidate)) {
-				return candidate;
-			}
-		} catch { /* ignore */ }
-	}
-
-	logger.warn("[Claude Code] Could not find node binary, falling back to 'node'");
-	return "node";
-}
-
 export async function claudeCodeMessage(
 	prompt: string,
 	oauthToken: string,
@@ -469,12 +428,12 @@ export async function openAIMessage(
 		const image = await openai.images.generate({
 			model,
 			prompt,
-			size: size as Parameters<typeof openai.images.generate>[0]["size"],
-			quality: normalizedQuality as Parameters<typeof openai.images.generate>[0]["quality"],
+			size: size,
+			quality: normalizedQuality,
 			n: numberOfImages,
 			response_format: response_format ?? "url",
 		});
-		let imageURLs: string[] = [];
+		const imageURLs: string[] = [];
 		image.data?.map((image) => {
 			if (image.b64_json) {
 				imageURLs.push(`data:image/png;base64,${image.b64_json}`);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -57,7 +57,7 @@ async function retryWithBackoff<T>(
 			if (status === 429 && attempt < maxRetries) {
 				const delay = baseDelayMs * Math.pow(2, attempt);
 				const jitter = Math.random() * delay * 0.5;
-				await new Promise((r) => activeWindow.setTimeout(r, delay + jitter));
+				await new Promise((r) => window.setTimeout(r, delay + jitter));
 				continue;
 			}
 			if (status === 429) {
@@ -118,12 +118,14 @@ export async function fetchOllamaContextWindows(
 	const result: Record<string, number> = {};
 	for (const name of modelNames) {
 		try {
-			const res = await fetch(`${host}/api/show`, {
+			const res = await requestUrl({
+				url: `${host}/api/show`,
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ name }),
+				throw: false,
 			});
-			const response = await res.json();
+			const response = res.json;
 			const fromInfo = response?.model_info?.["llm.context_length"];
 			const fromParams = response?.parameters
 				? parseInt(
@@ -143,15 +145,15 @@ export async function fetchOllamaContextWindows(
 }
 
 export async function fetchOllamaModels(host: string): Promise<string[]> {
-	const res = await fetch(`${host}/api/tags`);
-	const response = await res.json();
+	const res = await requestUrl({ url: `${host}/api/tags`, throw: false });
+	const response = res.json;
 	return (response.models || []).map((m: { name: string }) => m.name);
 }
 
 /** Fetches the list of models currently loaded in LM Studio via its OpenAI-compatible /v1/models endpoint. */
 export async function fetchLMStudioModels(host: string): Promise<string[]> {
-	const res = await fetch(`${host}/v1/models`);
-	const response = await res.json();
+	const res = await requestUrl({ url: `${host}/v1/models`, throw: false });
+	const response = res.json;
 	return (response.data || []).map((m: { id: string }) => m.id);
 }
 
@@ -198,7 +200,7 @@ export async function mistralMessage(params: ChatParams, mistralAPIKey: string) 
 					}
 				}
 			}
-			return activeWindow.fetch(url, init);
+			return window.fetch(url, init);
 		},
 	});
 


### PR DESCRIPTION
## Summary

- **Claude Code SDK install in settings** — surfaces the one-time runtime SDK download (~69 MB) as a \"Download SDK\" button under Settings → Anthropic → Claude Code, so users see it before trying to send a message rather than as a cryptic error mid-chat
- **Manifest linter** — adds `scripts/check-manifest.mjs` (run as part of `npm run build` and standalone via `npm run lint:manifest`) to fail fast if `manifest.json` is missing required fields like `version`, preventing the release footgun we've hit before
- **ESLint fixes** — resolves all 7 errors and 17 warnings from `npm run lint`, including unnecessary type assertions, unused variables, bare `console.*` calls, and `==` vs `===`
- **Obsidian plugin review warnings** — addresses the automated review scan findings: `activeWindow.*` → `window.*` for timers, `document` → `activeDocument` for DOM calls, `fetch` → `requestUrl`, `vault.trash()` → `fileManager.trashFile()`, `setWarning` → `setDestructive`, unawaited promise `void` annotations, `activeLeaf` deprecation, and manifest metadata fixes
- **FAB/StatusBar init regression fix** — reverts the two `activeWindow.setTimeout` → `window.setTimeout` changes for FAB and Ask AI popup initialization, which caused them to silently fail to render on plugin load

## Test plan

- [ ] Open Settings → Anthropic → Claude Code — confirm \"Runtime SDK\" row appears with \"Download SDK\" button if SDK not installed, or status message if already installed
- [ ] Run `npm run build` with a blank `version` field in `manifest.json` — confirm build fails with a clear error
- [ ] Run `npm run lint` — confirm 0 errors, 0 warnings
- [ ] Enable FAB in settings, reload plugin — confirm FAB appears
- [ ] Enable \"Ask AI\" status bar button, reload plugin — confirm it appears and popover opens on click
- [ ] Send a message with any provider — confirm no regressions in chat flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)