### PR TITLE
Add built-in MCP server for external vault access

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,34 @@ Download the plugin via the community plugin browser.
 | GPT4All  | Supported  |
 | Ollama | Supported |
 
+# MCP Server
+
+The plugin can run a built-in MCP ([Model Context Protocol](https://modelcontextprotocol.io)) server so Claude Desktop, or any other MCP-compatible client, can read and write this vault directly — no separate companion plugin required.
+
+**Setup:**
+1. In plugin settings, go to **General → Features** and enable **MCP Server**. A bearer token is generated automatically.
+2. Open the new **MCP Server** tab to see the port, bearer token, and a ready-to-copy `claude_desktop_config.json` snippet.
+3. Add that snippet to your Claude Desktop config file, then restart Claude Desktop:
+
+```json
+{
+  "mcpServers": {
+    "obsidian-vault": {
+      "url": "http://127.0.0.1:27125/mcp",
+      "headers": {
+        "Authorization": "Bearer <your-token>"
+      }
+    }
+  }
+}
+```
+
+**Notes:**
+- The server binds to `127.0.0.1` only and requires the bearer token on every request — it is not reachable from other devices on your network.
+- Available tools: `list_files`, `read_file`, `search_vault` (read-only, run immediately) and `create_file`, `edit_file`, `move_file`, `delete_file` (each pops a confirmation dialog in Obsidian before running, the same as in-app agent actions).
+- Desktop only. Disabled by default — enabling it opens a local port only for as long as the toggle stays on.
+- Regenerating the bearer token immediately invalidates the old one; update any connected MCP clients afterward.
+
 # Credits
 - Johnny ✨
 - Ryan Mahoney

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,9 @@
 				"@anthropic-ai/sdk": "0.101.0",
 				"@google/genai": "2.8.0",
 				"@huggingface/transformers": "^4.2.0",
-				"openai": "6.42.0"
+				"@modelcontextprotocol/sdk": "^1.29.0",
+				"openai": "6.42.0",
+				"zod": "^4.4.3"
 			},
 			"devDependencies": {
 				"@eslint/js": "10.0.1",
@@ -882,9 +884,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1073,7 +1075,6 @@
 			"resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
 			"integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18.14.1"
 			},
@@ -2207,7 +2208,6 @@
 			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
 			"integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@hono/node-server": "^1.19.9",
 				"ajv": "^8.17.1",
@@ -2337,6 +2337,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
 			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@protobufjs/inquire": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+			"integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/path": {
@@ -3648,7 +3654,6 @@
 			"resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
 			"integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"mime-types": "^3.0.0",
 				"negotiator": "^1.0.0"
@@ -3719,7 +3724,6 @@
 			"resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
 			"integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ajv": "^8.0.0"
 			},
@@ -4258,7 +4262,6 @@
 			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
 			"integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"bytes": "^3.1.2",
 				"content-type": "^1.0.5",
@@ -4371,7 +4374,6 @@
 			"resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
 			"integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -4810,7 +4812,6 @@
 			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
 			"integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -4824,7 +4825,6 @@
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
 			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -4841,7 +4841,6 @@
 			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
 			"integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -4851,7 +4850,6 @@
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
 			"integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=6.6.0"
 			}
@@ -4868,7 +4866,6 @@
 			"resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
 			"integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"object-assign": "^4",
 				"vary": "^1"
@@ -5189,7 +5186,6 @@
 			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
 			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -5428,8 +5424,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
 			"integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/ejs": {
 			"version": "3.1.10",
@@ -5469,7 +5464,6 @@
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
 			"integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -5512,9 +5506,9 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.24.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.1.tgz",
-			"integrity": "sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw==",
+			"version": "5.24.2",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
+			"integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5819,8 +5813,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
 			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
@@ -5951,9 +5944,9 @@
 			}
 		},
 		"node_modules/eslint-module-utils": {
-			"version": "2.13.0",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
-			"integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
+			"integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6049,9 +6042,9 @@
 			"license": "MIT"
 		},
 		"node_modules/eslint-plugin-json-schema-validator/node_modules/brace-expansion": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6108,9 +6101,9 @@
 			"license": "MIT"
 		},
 		"node_modules/eslint-plugin-n/node_modules/brace-expansion": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-			"integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6157,9 +6150,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-obsidianmd": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.4.0.tgz",
-			"integrity": "sha512-qZsh8ydaeO7bC+XADWHGG9+CEwiKjoL7arZo1I93e0UHdQ863Jzt+xRk5VI0vo97SIJrA4vWwuz9K9/fggO35g==",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-obsidianmd/-/eslint-plugin-obsidianmd-0.4.1.tgz",
+			"integrity": "sha512-Nv3593kVsFOS8kir/HWaJ5CR3xcyiPWEPyXst5Pib8mxRYYuLYPpJS2ALMoZXHulHyiGwoYW8AaxvLRc4rhrRg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6355,9 +6348,9 @@
 			"license": "MIT"
 		},
 		"node_modules/eslint-plugin-obsidianmd/node_modules/brace-expansion": {
-			"version": "1.1.15",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-			"integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6838,7 +6831,6 @@
 			"resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
 			"integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -6878,7 +6870,6 @@
 			"resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
 			"integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"eventsource-parser": "^3.0.1"
 			},
@@ -6891,7 +6882,6 @@
 			"resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
 			"integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18.0.0"
 			}
@@ -7037,7 +7027,6 @@
 			"resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
 			"integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"accepts": "^2.0.0",
 				"body-parser": "^2.2.1",
@@ -7081,7 +7070,6 @@
 			"resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
 			"integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ip-address": "^10.2.0"
 			},
@@ -7365,7 +7353,6 @@
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
 			"integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"debug": "^4.4.0",
 				"encodeurl": "^2.0.0",
@@ -7486,7 +7473,6 @@
 			"resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
 			"integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -7496,7 +7482,6 @@
 			"resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
 			"integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -8060,11 +8045,10 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "4.12.27",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
-			"integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
+			"version": "4.12.23",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+			"integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=16.9.0"
 			}
@@ -8127,7 +8111,6 @@
 			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
 			"integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"depd": "~2.0.0",
 				"inherits": "~2.0.4",
@@ -8346,7 +8329,6 @@
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
 			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.10"
 			}
@@ -8695,8 +8677,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
 			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/is-regex": {
 			"version": "1.2.1",
@@ -9230,7 +9211,6 @@
 			"resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
 			"integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/panva"
 			}
@@ -9324,8 +9304,7 @@
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
 			"integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
-			"license": "BSD-2-Clause",
-			"peer": true
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
@@ -9869,7 +9848,6 @@
 			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
 			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -9879,7 +9857,6 @@
 			"resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
 			"integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -9892,7 +9869,6 @@
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
 			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -9902,7 +9878,6 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
 			"integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"mime-db": "^1.54.0"
 			},
@@ -10122,7 +10097,6 @@
 			"resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
 			"integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -10450,7 +10424,6 @@
 			"resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
 			"integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"ee-first": "1.1.1"
 			},
@@ -10774,7 +10747,6 @@
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
 			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -10843,7 +10815,6 @@
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
 			"integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/express"
@@ -10888,7 +10859,6 @@
 			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
 			"integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=16.20.0"
 			}
@@ -10991,9 +10961,9 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "7.6.4",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-			"integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
+			"integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -11003,6 +10973,7 @@
 				"@protobufjs/eventemitter": "^1.1.1",
 				"@protobufjs/fetch": "^1.1.1",
 				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.2",
 				"@protobufjs/path": "^1.1.2",
 				"@protobufjs/pool": "^1.1.0",
 				"@protobufjs/utf8": "^1.1.1",
@@ -11018,7 +10989,6 @@
 			"resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
 			"integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"forwarded": "0.2.0",
 				"ipaddr.js": "1.9.1"
@@ -11090,7 +11060,6 @@
 			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
 			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
 			"license": "BSD-3-Clause",
-			"peer": true,
 			"dependencies": {
 				"side-channel": "^1.1.0"
 			},
@@ -11123,7 +11092,6 @@
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
 			"integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -11133,7 +11101,6 @@
 			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
 			"integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"bytes": "~3.1.2",
 				"http-errors": "~2.0.1",
@@ -11627,7 +11594,6 @@
 			"resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
 			"integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"debug": "^4.4.0",
 				"depd": "^2.0.0",
@@ -11820,7 +11786,6 @@
 			"resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
 			"integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"debug": "^4.4.3",
 				"encodeurl": "^2.0.0",
@@ -11873,7 +11838,6 @@
 			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
 			"integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"encodeurl": "^2.0.0",
 				"escape-html": "^1.0.3",
@@ -11948,8 +11912,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
 			"integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-			"license": "ISC",
-			"peer": true
+			"license": "ISC"
 		},
 		"node_modules/sharp": {
 			"version": "0.34.5",
@@ -12270,7 +12233,6 @@
 			"resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
 			"integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -12764,7 +12726,6 @@
 			"resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
 			"integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=0.6"
 			}
@@ -12900,7 +12861,6 @@
 			"resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
 			"integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"content-type": "^2.0.0",
 				"media-typer": "^1.1.0",
@@ -12919,7 +12879,6 @@
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
 			"integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -13097,7 +13056,6 @@
 			"resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 			"integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -13152,7 +13110,6 @@
 			"resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
 			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">= 0.8"
 			}
@@ -14038,7 +13995,6 @@
 			"resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
 			"integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
 			"license": "MIT",
-			"peer": true,
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
@@ -14048,7 +14004,6 @@
 			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
 			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
 			"license": "ISC",
-			"peer": true,
 			"peerDependencies": {
 				"zod": "^3.25.28 || ^4"
 			}

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
 		"@anthropic-ai/sdk": "0.101.0",
 		"@google/genai": "2.8.0",
 		"@huggingface/transformers": "^4.2.0",
-		"openai": "6.42.0"
+		"@modelcontextprotocol/sdk": "^1.29.0",
+		"openai": "6.42.0",
+		"zod": "^4.4.3"
 	}
 }

--- a/src/Settings/LLMSettingsModal.ts
+++ b/src/Settings/LLMSettingsModal.ts
@@ -13,6 +13,7 @@ import {
 	TFile,
 } from "obsidian";
 import { FeatureSettings } from "Types/types";
+import { generateMcpToken } from "mcp/token";
 import { changeDefaultModel, fetchOllamaModels, fetchOllamaContextWindows, fetchLMStudioModels, getGpt4AllPath } from "utils/utils";
 import { getErrorMessage } from "utils/errorUtils";
 import { AdapterWithBasePath, AppWithSetting } from "Types/obsidian-internals";
@@ -116,6 +117,7 @@ export class LLMSettingsModal extends Modal {
 				{ id: "projects",       label: "Projects",        icon: "folder-open",     featureGate: "projects" },
 				{ id: "assistants",     label: "Assistants",      icon: "bot",             featureGate: "assistants" },
 				{ id: "transcription",  label: "Transcription",   icon: "mic",             featureGate: "transcription" },
+				{ id: "mcp-server",     label: "MCP Server",      icon: "server",          featureGate: "mcpServer" },
 			],
 		},
 		{
@@ -307,6 +309,7 @@ export class LLMSettingsModal extends Modal {
 			case "assistants":      this.renderAssistants();      break;
 			case "obsidian-agent":  this.renderObsidianAgent();   break;
 			case "transcription":   this.renderTranscription();   break;
+			case "mcp-server":      this.renderMcpServer();       break;
 		}
 	}
 
@@ -582,6 +585,25 @@ export class LLMSettingsModal extends Modal {
 					this.plugin.initVaultIndexer();
 				},
 			},
+			{
+				key: "mcpServer",
+				name: "MCP Server",
+				desc: "Runs a local MCP (Model Context Protocol) server so Claude Desktop or other MCP clients can read and write this vault directly, subject to the same permission confirmation as in-app agent actions.",
+				onEnable: async () => {
+					this.plugin.settings.mcpServerSettings.enabled = true;
+					await this.plugin.saveSettings();
+					await this.plugin.initMcpServer();
+				},
+				onDisable: async () => {
+					this.plugin.settings.mcpServerSettings.enabled = false;
+					if (this.activeTab === "mcp-server") {
+						this.activeTab = "general";
+						this.renderTab("general");
+					}
+					await this.plugin.saveSettings();
+					await this.plugin.initMcpServer();
+				},
+			},
 		];
 
 		for (const def of featureDefs) {
@@ -601,6 +623,7 @@ export class LLMSettingsModal extends Modal {
 									assistants: false,
 									memory: false,
 									vaultSearch: false,
+									mcpServer: false,
 								};
 							}
 							this.plugin.settings.featureSettings[def.key] = value;
@@ -2581,6 +2604,108 @@ export class LLMSettingsModal extends Modal {
 					await this.plugin.saveSettings();
 				});
 			});
+	}
+
+	private renderMcpServer() {
+		const el = this.mainContentEl;
+		const s = this.plugin.settings.mcpServerSettings;
+
+		if (!Platform.isDesktop) {
+			const notice = this.addSettingGroup(el);
+			new Setting(notice)
+				.setName("Desktop only")
+				.setDesc("The MCP server requires a local network listener and is not available on mobile.");
+			return;
+		}
+
+		// ── Enable ───────────────────────────────────────────────────────────
+		const enableGroup = this.addSettingGroup(el);
+		new Setting(enableGroup)
+			.setName("Enable MCP server")
+			.setDesc(
+				"Runs a local MCP (Model Context Protocol) server on 127.0.0.1 so Claude Desktop or another " +
+				"MCP client can read and write this vault. Writes (create, edit, move, delete) still require " +
+				"your confirmation in a popup, exactly like in-app agent actions."
+			)
+			.addToggle((toggle) => {
+				toggle.setValue(s.enabled).onChange(async (value) => {
+					this.plugin.settings.mcpServerSettings.enabled = value;
+					await this.plugin.saveSettings();
+					await this.plugin.initMcpServer();
+					this.renderTab("mcp-server");
+				});
+			});
+
+		if (!s.enabled) return;
+
+		// ── Connection ───────────────────────────────────────────────────────
+		const connGroup = this.addSettingGroup(el, "Connection");
+
+		new Setting(connGroup)
+			.setName("Port")
+			.setDesc("Port the server listens on (127.0.0.1 only). Restarts the server when changed.")
+			.addText((text) => {
+				text.setValue(String(s.port)).onChange(async (value) => {
+					const port = parseInt(value, 10);
+					if (!Number.isInteger(port) || port < 1 || port > 65535) return;
+					this.plugin.settings.mcpServerSettings.port = port;
+					await this.plugin.saveSettings();
+					await this.plugin.initMcpServer();
+				});
+			});
+
+		let tokenTextEl: HTMLInputElement | undefined;
+		new Setting(connGroup)
+			.setName("Bearer token")
+			.setDesc("Required on every request as \"Authorization: Bearer <token>\".")
+			.addText((text) => {
+				tokenTextEl = text.inputEl;
+				text.setValue(s.token).setDisabled(true);
+				text.inputEl.addClass("llm-mcp-token-field");
+			})
+			.addButton((btn) => {
+				btn.setButtonText("Copy").onClick(async () => {
+					await navigator.clipboard.writeText(this.plugin.settings.mcpServerSettings.token);
+					new Notice("Token copied to clipboard.");
+				});
+			})
+			.addButton((btn) => {
+				btn.setButtonText("Regenerate").onClick(async () => {
+					this.plugin.settings.mcpServerSettings.token = generateMcpToken();
+					await this.plugin.saveSettings();
+					if (tokenTextEl) tokenTextEl.value = this.plugin.settings.mcpServerSettings.token;
+					new Notice("Bearer token regenerated. Update any connected MCP clients.");
+				});
+			});
+
+		// ── Claude Desktop config snippet ───────────────────────────────────
+		const configGroup = this.addSettingGroup(el, "Claude Desktop setup");
+		new Setting(configGroup)
+			.setName("claude_desktop_config.json")
+			.setDesc("Add this entry to your Claude Desktop config's \"mcpServers\" object, then restart Claude Desktop.");
+
+		const snippet = JSON.stringify(
+			{
+				mcpServers: {
+					"obsidian-vault": {
+						url: `http://127.0.0.1:${s.port}/mcp`,
+						headers: { Authorization: `Bearer ${s.token}` },
+					},
+				},
+			},
+			null,
+			2
+		);
+
+		const pre = configGroup.createEl("pre", { cls: "llm-mcp-config-snippet" });
+		pre.createEl("code", { text: snippet });
+
+		new Setting(configGroup).addButton((btn) => {
+			btn.setButtonText("Copy snippet").onClick(async () => {
+				await navigator.clipboard.writeText(snippet);
+				new Notice("Config snippet copied to clipboard.");
+			});
+		});
 	}
 
 	// ── Helpers ────────────────────────────────────────────────────────────────

--- a/src/Types/types.ts
+++ b/src/Types/types.ts
@@ -322,6 +322,15 @@ export type SearxngSettings = {
 	maxResults: number;
 };
 
+export type McpServerSettings = {
+	/** Whether the built-in MCP (Model Context Protocol) server is running. */
+	enabled: boolean;
+	/** Port the Streamable HTTP MCP server listens on (127.0.0.1 only). */
+	port: number;
+	/** Bearer token required on every request. Generated on first enable. */
+	token: string;
+};
+
 export type FeatureSettings = {
 	/** Master gate for the Obsidian Agent feature (FAB / status-bar agent mode). */
 	obsidianAgent: boolean;
@@ -335,6 +344,8 @@ export type FeatureSettings = {
 	memory: boolean;
 	/** Master gate for the Vault Search (RAG / embeddings) feature. */
 	vaultSearch: boolean;
+	/** Master gate for the built-in MCP server feature. */
+	mcpServer: boolean;
 };
 
 export type WhisperBackend = "openai" | "sidecar";

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,6 +7,7 @@ import {
 	HistoryItem,
 	ImageQuality,
 	ImageSize,
+	McpServerSettings,
 	MemorySettings,
 	ObsidianAgentSettings,
 	ProjectSettings,
@@ -29,6 +30,10 @@ import { SkillRegistry } from "Skills/SkillRegistry";
 import { VaultIndexer } from "RAG/VaultIndexer";
 import { VectorStore } from "RAG/VectorStore";
 import { EmbeddingService, DEFAULT_EMBEDDING_MODELS } from "RAG/EmbeddingService";
+// Type-only — erased at build time, so this does NOT pull in the MCP SDK's node:http
+// dependency chain at plugin load. The real module is loaded lazily in initMcpServer().
+import type { McpTransportServer } from "mcp/transport";
+import { generateMcpToken } from "mcp/token";
 
 import { History } from "History/HistoryHandler";
 import { ChatHistory } from "services/ChatHistory";
@@ -117,6 +122,8 @@ export interface LLMPluginSettings {
 	whisperSettings: WhisperSettings;
 	/** SearXNG web search settings. */
 	searxngSettings: SearxngSettings;
+	/** Built-in MCP (Model Context Protocol) server settings. */
+	mcpServerSettings: McpServerSettings;
 	/**
 	 * Root vault folder for all AI feature data (default "AI").
 	 * Skills live at <rootVaultFolder>/Skills/<skill-name>/SKILL.md.
@@ -273,6 +280,11 @@ export const DEFAULT_SETTINGS: LLMPluginSettings = {
 		host: "http://localhost:8080",
 		maxResults: 5,
 	},
+	mcpServerSettings: {
+		enabled: false,
+		port: 27125,
+		token: "",
+	},
 	rootVaultFolder: "",
 	agentsFilePath: "AI/AGENTS.md",
 	hasOnboarded: false,
@@ -283,6 +295,7 @@ export const DEFAULT_SETTINGS: LLMPluginSettings = {
 		assistants: false,
 		memory: false,
 		vaultSearch: false,
+		mcpServer: false,
 	},
 };
 
@@ -353,6 +366,8 @@ export default class LLMPlugin extends Plugin {
 	sidecarManager: SidecarManager = new SidecarManager(this);
 	/** SearXNG web search service — null if searxngSettings.enabled is false. */
 	searxngService: SearxngService | null = null;
+	/** Built-in MCP server — null if mcpServerSettings.enabled is false or the platform isn't desktop. */
+	mcpServer: McpTransportServer | null = null;
 	/**
 	 * The most recently focused widget leaf. Updated by the active-leaf-change event.
 	 * Used to route "open chat file" and similar actions to the correct widget when
@@ -429,6 +444,7 @@ export default class LLMPlugin extends Plugin {
 		this.initMemoryService();
 		this.initWhisperService();
 		this.initSearxngService();
+		this.initMcpServer().catch((e) => logger.error("[MCP] Failed to initialise server:", e));
 		if (Platform.isDesktop) {
 			this.registerRagVaultEvents();
 		}
@@ -999,6 +1015,37 @@ export default class LLMPlugin extends Plugin {
 	}
 
 	/**
+	 * Start (or stop) the built-in MCP server based on current settings.
+	 * Safe to call after any settings change that affects it. The MCP SDK
+	 * module is imported dynamically — it pulls in a node:http dependency chain
+	 * that must never execute at plugin load on mobile (manifest isDesktopOnly: false).
+	 */
+	async initMcpServer(): Promise<void> {
+		if (this.mcpServer) {
+			await this.mcpServer.stop().catch(() => {});
+			this.mcpServer = null;
+		}
+
+		const s = this.settings.mcpServerSettings;
+		if (!Platform.isDesktop || !s?.enabled) return;
+
+		if (!s.token) {
+			s.token = generateMcpToken();
+			await this.saveSettings();
+		}
+
+		try {
+			const { McpTransportServer } = await import("mcp/transport");
+			const server = new McpTransportServer(this.app, () => this.settings.mcpServerSettings.token, this.manifest.version);
+			await server.start(s.port);
+			this.mcpServer = server;
+		} catch (e) {
+			logger.error("[MCP] Failed to start server:", e);
+			new Notice(`Failed to start MCP server on port ${s.port}: ${e instanceof Error ? e.message : String(e)}`, 6000);
+		}
+	}
+
+	/**
 	 * Re-initialise the SkillRegistry from current settings.
 	 * Call after the root vault folder setting changes.
 	 */
@@ -1059,6 +1106,8 @@ export default class LLMPlugin extends Plugin {
 
 		// Kill the ONNX worker child process if running.
 		EmbeddingService.unload();
+
+		this.mcpServer?.stop().catch(() => {});
 
 		this.fab.removeFab();
 		this.statusBarButton.remove();

--- a/src/mcp/McpPermissionModal.ts
+++ b/src/mcp/McpPermissionModal.ts
@@ -1,0 +1,73 @@
+import { App, ButtonComponent, Modal } from "obsidian";
+
+/**
+ * Confirmation gate for destructive MCP tool calls (create/edit/move/delete).
+ * Unlike the in-chat permission card (ChatContainer.showPermissionUI), an MCP
+ * request has no open conversation to render into — it can arrive at any time
+ * from an external client — so this uses a real Modal instead. Dismissing
+ * without an explicit choice (Escape, backdrop click) resolves to deny.
+ */
+export class McpPermissionModal extends Modal {
+	private decided = false;
+
+	constructor(
+		app: App,
+		private toolName: string,
+		private description: string,
+		private input: Record<string, unknown>,
+		private onDecision: (approved: boolean) => void
+	) {
+		super(app);
+	}
+
+	onOpen() {
+		const { contentEl } = this;
+		contentEl.createEl("h2", { text: `MCP tool request: ${this.toolName}` });
+		contentEl.createEl("p", { text: this.description });
+
+		const inputEntries = Object.entries(this.input);
+		if (inputEntries.length > 0) {
+			const pre = contentEl.createEl("pre", { cls: "llm-mcp-permission-input" });
+			pre.createEl("code", { text: JSON.stringify(this.input, null, 2) });
+		}
+
+		const buttonRow = contentEl.createDiv({ cls: "modal-button-container" });
+
+		new ButtonComponent(buttonRow)
+			.setButtonText("Deny")
+			.onClick(() => {
+				this.decided = true;
+				this.close();
+				this.onDecision(false);
+			});
+
+		new ButtonComponent(buttonRow)
+			.setButtonText("Allow")
+			.setCta()
+			.onClick(() => {
+				this.decided = true;
+				this.close();
+				this.onDecision(true);
+			});
+	}
+
+	onClose() {
+		this.contentEl.empty();
+		if (!this.decided) {
+			this.decided = true;
+			this.onDecision(false);
+		}
+	}
+}
+
+/** Shows the permission modal and resolves once the user makes a choice (or dismisses it, which denies). */
+export function requestMcpApproval(
+	app: App,
+	toolName: string,
+	description: string,
+	input: Record<string, unknown>
+): Promise<boolean> {
+	return new Promise<boolean>((resolve) => {
+		new McpPermissionModal(app, toolName, description, input, resolve).open();
+	});
+}

--- a/src/mcp/pathGuard.ts
+++ b/src/mcp/pathGuard.ts
@@ -1,0 +1,56 @@
+/**
+ * Resolves an MCP-supplied path against the vault root and rejects any attempt
+ * to escape it — including encoded and double-encoded `../` traversal and
+ * absolute/drive-letter paths. Obsidian vault paths are always POSIX-style and
+ * relative to the vault root, so the checks below operate purely on the string
+ * form (there is no filesystem call to bypass here).
+ */
+export class PathTraversalError extends Error {}
+
+export function guardVaultPath(rawPath: string): string {
+	if (typeof rawPath !== "string" || rawPath.length === 0) {
+		throw new PathTraversalError("Path must be a non-empty string");
+	}
+
+	// Repeatedly percent-decode to catch double-encoded traversal (e.g. %252e%252e).
+	let decoded = rawPath;
+	for (let i = 0; i < 5; i++) {
+		let next: string;
+		try {
+			next = decodeURIComponent(decoded);
+		} catch {
+			break;
+		}
+		if (next === decoded) break;
+		decoded = next;
+	}
+
+	if (decoded.includes("\0")) {
+		throw new PathTraversalError("Path contains a null byte");
+	}
+
+	const normalized = decoded.replace(/\\/g, "/");
+	if (normalized.startsWith("/") || /^[a-zA-Z]:/.test(normalized)) {
+		throw new PathTraversalError(`Absolute paths are not allowed: ${rawPath}`);
+	}
+
+	const segments = normalized.split("/");
+	const resolved: string[] = [];
+	for (const segment of segments) {
+		if (segment === "" || segment === ".") continue;
+		if (segment === "..") {
+			if (resolved.length === 0) {
+				throw new PathTraversalError(`Path escapes the vault root: ${rawPath}`);
+			}
+			resolved.pop();
+			continue;
+		}
+		resolved.push(segment);
+	}
+
+	if (resolved.length === 0) {
+		throw new PathTraversalError(`Path resolves to the vault root: ${rawPath}`);
+	}
+
+	return resolved.join("/");
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,24 @@
+import { App } from "obsidian";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerListFilesTool } from "mcp/tools/listFiles";
+import { registerReadFileTool } from "mcp/tools/readFile";
+import { registerSearchVaultTool } from "mcp/tools/searchVault";
+import { registerCreateFileTool } from "mcp/tools/createFile";
+import { registerEditFileTool } from "mcp/tools/editFile";
+import { registerMoveFileTool } from "mcp/tools/moveFile";
+import { registerDeleteFileTool } from "mcp/tools/deleteFile";
+
+/** Builds a fresh McpServer instance with all vault tools registered. One is created per request (see transport.ts) — cheap, and matches the SDK's stateless-server reference pattern. */
+export function createMcpServer(app: App, version: string): McpServer {
+	const server = new McpServer({ name: "obsidian-vault", version });
+
+	registerListFilesTool(server, app);
+	registerReadFileTool(server, app);
+	registerSearchVaultTool(server, app);
+	registerCreateFileTool(server, app);
+	registerEditFileTool(server, app);
+	registerMoveFileTool(server, app);
+	registerDeleteFileTool(server, app);
+
+	return server;
+}

--- a/src/mcp/token.ts
+++ b/src/mcp/token.ts
@@ -1,0 +1,10 @@
+/**
+ * Generates a bearer token using Web Crypto (available in the Electron renderer on both
+ * desktop and mobile) — deliberately avoids Node's `crypto` module so this can be imported
+ * eagerly from the settings UI without pulling in any desktop-only dependency chain.
+ */
+export function generateMcpToken(): string {
+	const bytes = new Uint8Array(32);
+	crypto.getRandomValues(bytes);
+	return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}

--- a/src/mcp/toolResult.ts
+++ b/src/mcp/toolResult.ts
@@ -1,0 +1,19 @@
+import { VaultOpResult } from "mcp/vaultOps";
+
+export type McpToolResult = {
+	content: Array<{ type: "text"; text: string }>;
+	isError?: boolean;
+};
+
+export function textResult(text: string): McpToolResult {
+	return { content: [{ type: "text", text }] };
+}
+
+export function errorResult(text: string): McpToolResult {
+	return { content: [{ type: "text", text }], isError: true };
+}
+
+export function fromVaultOpResult<T>(op: VaultOpResult<T>, formatSuccess: (result: T) => string): McpToolResult {
+	if (!op.success) return errorResult(op.error);
+	return textResult(formatSuccess(op.result));
+}

--- a/src/mcp/tools/createFile.ts
+++ b/src/mcp/tools/createFile.ts
@@ -1,0 +1,31 @@
+import { App } from "obsidian";
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createFile } from "mcp/vaultOps";
+import { fromVaultOpResult, errorResult } from "mcp/toolResult";
+import { requestMcpApproval } from "mcp/McpPermissionModal";
+
+export function registerCreateFileTool(server: McpServer, app: App): void {
+	server.registerTool(
+		"create_file",
+		{
+			description: "Create a new note in the vault. Fails if a file already exists at the given path.",
+			inputSchema: {
+				path: z.string().describe("Vault-relative path for the new note, e.g. \"Folder/Note.md\"."),
+				content: z.string().describe("Initial contents of the note."),
+			},
+		},
+		async ({ path, content }) => {
+			const approved = await requestMcpApproval(
+				app,
+				"create_file",
+				`Create a new note at "${path}"?`,
+				{ path, content }
+			);
+			if (!approved) return errorResult(`Denied by user: create_file ${path}`);
+
+			const op = await createFile(app, path, content);
+			return fromVaultOpResult(op, (result) => result);
+		}
+	);
+}

--- a/src/mcp/tools/deleteFile.ts
+++ b/src/mcp/tools/deleteFile.ts
@@ -1,0 +1,30 @@
+import { App } from "obsidian";
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { deleteFile } from "mcp/vaultOps";
+import { fromVaultOpResult, errorResult } from "mcp/toolResult";
+import { requestMcpApproval } from "mcp/McpPermissionModal";
+
+export function registerDeleteFileTool(server: McpServer, app: App): void {
+	server.registerTool(
+		"delete_file",
+		{
+			description: "Delete a note from the vault (moved to trash, following the user's Obsidian trash preference).",
+			inputSchema: {
+				path: z.string().describe("Vault-relative path of the note to delete."),
+			},
+		},
+		async ({ path }) => {
+			const approved = await requestMcpApproval(
+				app,
+				"delete_file",
+				`Delete "${path}"?`,
+				{ path }
+			);
+			if (!approved) return errorResult(`Denied by user: delete_file ${path}`);
+
+			const op = await deleteFile(app, path);
+			return fromVaultOpResult(op, (result) => result);
+		}
+	);
+}

--- a/src/mcp/tools/editFile.ts
+++ b/src/mcp/tools/editFile.ts
@@ -1,0 +1,31 @@
+import { App } from "obsidian";
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { editFile } from "mcp/vaultOps";
+import { fromVaultOpResult, errorResult } from "mcp/toolResult";
+import { requestMcpApproval } from "mcp/McpPermissionModal";
+
+export function registerEditFileTool(server: McpServer, app: App): void {
+	server.registerTool(
+		"edit_file",
+		{
+			description: "Replace the full contents of an existing note in the vault.",
+			inputSchema: {
+				path: z.string().describe("Vault-relative path to the note to modify."),
+				content: z.string().describe("New contents that will replace the note's existing contents."),
+			},
+		},
+		async ({ path, content }) => {
+			const approved = await requestMcpApproval(
+				app,
+				"edit_file",
+				`Overwrite the contents of "${path}"?`,
+				{ path, content }
+			);
+			if (!approved) return errorResult(`Denied by user: edit_file ${path}`);
+
+			const op = await editFile(app, path, content);
+			return fromVaultOpResult(op, (result) => result);
+		}
+	);
+}

--- a/src/mcp/tools/listFiles.ts
+++ b/src/mcp/tools/listFiles.ts
@@ -1,0 +1,21 @@
+import { App } from "obsidian";
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { listFiles } from "mcp/vaultOps";
+import { fromVaultOpResult } from "mcp/toolResult";
+
+export function registerListFilesTool(server: McpServer, app: App): void {
+	server.registerTool(
+		"list_files",
+		{
+			description: "List files in the vault, optionally scoped to a folder.",
+			inputSchema: {
+				folder: z.string().optional().describe("Vault-relative folder path to scope the listing to. Omit to list the whole vault."),
+			},
+		},
+		async ({ folder }) => {
+			const op = await listFiles(app, folder);
+			return fromVaultOpResult(op, (files) => (files.length > 0 ? files.join("\n") : "No files found."));
+		}
+	);
+}

--- a/src/mcp/tools/moveFile.ts
+++ b/src/mcp/tools/moveFile.ts
@@ -1,0 +1,31 @@
+import { App } from "obsidian";
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { moveFile } from "mcp/vaultOps";
+import { fromVaultOpResult, errorResult } from "mcp/toolResult";
+import { requestMcpApproval } from "mcp/McpPermissionModal";
+
+export function registerMoveFileTool(server: McpServer, app: App): void {
+	server.registerTool(
+		"move_file",
+		{
+			description: "Rename or move a note to a new vault-relative path. Fails if a file already exists at the destination.",
+			inputSchema: {
+				path: z.string().describe("Vault-relative path of the note to move."),
+				new_path: z.string().describe("New vault-relative path for the note."),
+			},
+		},
+		async ({ path, new_path }) => {
+			const approved = await requestMcpApproval(
+				app,
+				"move_file",
+				`Move "${path}" to "${new_path}"?`,
+				{ path, new_path }
+			);
+			if (!approved) return errorResult(`Denied by user: move_file ${path} -> ${new_path}`);
+
+			const op = await moveFile(app, path, new_path);
+			return fromVaultOpResult(op, (result) => result);
+		}
+	);
+}

--- a/src/mcp/tools/readFile.ts
+++ b/src/mcp/tools/readFile.ts
@@ -1,0 +1,21 @@
+import { App } from "obsidian";
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { readFile } from "mcp/vaultOps";
+import { fromVaultOpResult } from "mcp/toolResult";
+
+export function registerReadFileTool(server: McpServer, app: App): void {
+	server.registerTool(
+		"read_file",
+		{
+			description: "Return the contents of a note in the vault.",
+			inputSchema: {
+				path: z.string().describe("Vault-relative path to the note, e.g. \"Folder/Note.md\"."),
+			},
+		},
+		async ({ path }) => {
+			const op = await readFile(app, path);
+			return fromVaultOpResult(op, (content) => content);
+		}
+	);
+}

--- a/src/mcp/tools/searchVault.ts
+++ b/src/mcp/tools/searchVault.ts
@@ -1,0 +1,26 @@
+import { App } from "obsidian";
+import { z } from "zod";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { searchVault } from "mcp/vaultOps";
+import { fromVaultOpResult } from "mcp/toolResult";
+
+export function registerSearchVaultTool(server: McpServer, app: App): void {
+	server.registerTool(
+		"search_vault",
+		{
+			description: "Case-insensitive text search across markdown notes in the vault. Returns matching file paths, line numbers, and excerpts.",
+			inputSchema: {
+				query: z.string().describe("Text to search for."),
+				folder: z.string().optional().describe("Vault-relative folder path to scope the search to. Omit to search the whole vault."),
+			},
+		},
+		async ({ query, folder }) => {
+			const op = await searchVault(app, query, folder);
+			return fromVaultOpResult(op, (matches) => {
+				if (matches.length === 0) return `No matches found for "${query}".`;
+				const lines = matches.map(m => `${m.path} (line ${m.line}): ${m.excerpt}`);
+				return `Found ${matches.length} match${matches.length === 1 ? "" : "es"}:\n\n${lines.join("\n")}`;
+			});
+		}
+	);
+}

--- a/src/mcp/transport.ts
+++ b/src/mcp/transport.ts
@@ -1,0 +1,153 @@
+import { App, Platform } from "obsidian";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { createMcpServer } from "mcp/server";
+import { logger } from "utils/logger";
+
+// Type-only references — erased at build time, no runtime import. The
+// runtime module is required lazily inside the functions that need it (see
+// start()/safeCompare()) since this whole file is only ever dynamically
+// imported from main.ts behind a Platform.isDesktop check.
+type HttpIncomingMessage = import("http").IncomingMessage;
+type HttpServerResponse = import("http").ServerResponse;
+type HttpServer = import("http").Server;
+
+const MAX_BODY_BYTES = 10 * 1024 * 1024;
+const ALLOWED_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+function sendJsonRpcError(res: HttpServerResponse, status: number, message: string): void {
+	if (res.headersSent) return;
+	res.writeHead(status, { "Content-Type": "application/json" });
+	res.end(JSON.stringify({ jsonrpc: "2.0", error: { code: -32000, message }, id: null }));
+}
+
+function hasValidHost(req: HttpIncomingMessage): boolean {
+	const hostHeader = req.headers.host;
+	if (!hostHeader) return false;
+	try {
+		const hostname = new URL(`http://${hostHeader}`).hostname;
+		return ALLOWED_HOSTNAMES.has(hostname);
+	} catch {
+		return false;
+	}
+}
+
+function safeCompare(a: string, b: string): boolean {
+	if (!Platform.isDesktop) return false;
+	// eslint-disable-next-line @typescript-eslint/no-require-imports -- Node builtin; guarded by the Platform.isDesktop check above
+	const { timingSafeEqual } = require("crypto") as typeof import("crypto");
+	const bufA = Buffer.from(a);
+	const bufB = Buffer.from(b);
+	if (bufA.length !== bufB.length) return false;
+	return timingSafeEqual(bufA, bufB);
+}
+
+function hasValidAuth(req: HttpIncomingMessage, token: string): boolean {
+	const header = req.headers["authorization"];
+	if (typeof header !== "string") return false;
+	const match = /^Bearer (.+)$/.exec(header);
+	if (!match) return false;
+	return safeCompare(match[1], token);
+}
+
+function readJsonBody(req: HttpIncomingMessage): Promise<unknown> {
+	return new Promise((resolve, reject) => {
+		let data = "";
+		let size = 0;
+		req.on("data", (chunk: Buffer) => {
+			size += chunk.length;
+			if (size > MAX_BODY_BYTES) {
+				reject(new Error("Payload too large"));
+				req.destroy();
+				return;
+			}
+			data += chunk.toString("utf8");
+		});
+		req.on("end", () => {
+			if (!data) return resolve(undefined);
+			try {
+				resolve(JSON.parse(data));
+			} catch (e) {
+				reject(e instanceof Error ? e : new Error(String(e)));
+			}
+		});
+		req.on("error", reject);
+	});
+}
+
+/**
+ * In-process Streamable HTTP MCP server, bound to 127.0.0.1 only.
+ * Runs in stateless mode (a fresh McpServer + transport per request) — this
+ * plugin serves a single local user, so per-session state isn't worth the
+ * complexity, and it matches the SDK's own documented stateless example.
+ */
+export class McpTransportServer {
+	private httpServer: HttpServer | null = null;
+
+	constructor(
+		private app: App,
+		private getToken: () => string,
+		private version: string
+	) {}
+
+	start(port: number): Promise<void> {
+		if (!Platform.isDesktop) return Promise.reject(new Error("MCP server requires Obsidian Desktop."));
+		// eslint-disable-next-line @typescript-eslint/no-require-imports -- Node builtin; guarded by the Platform.isDesktop check above
+		const http = require("http") as typeof import("http");
+		return new Promise((resolve, reject) => {
+			const server = http.createServer((req, res) => {
+				this.handleRequest(req, res).catch((e) => {
+					logger.error("[MCP] Request handling failed:", e);
+					sendJsonRpcError(res, 500, "Internal server error");
+				});
+			});
+			server.once("error", reject);
+			server.listen(port, "127.0.0.1", () => {
+				server.removeListener("error", reject);
+				server.on("error", (e) => logger.error("[MCP] Server error:", e));
+				this.httpServer = server;
+				resolve();
+			});
+		});
+	}
+
+	stop(): Promise<void> {
+		return new Promise((resolve) => {
+			if (!this.httpServer) return resolve();
+			const server = this.httpServer;
+			this.httpServer = null;
+			server.close(() => resolve());
+		});
+	}
+
+	private async handleRequest(req: HttpIncomingMessage, res: HttpServerResponse): Promise<void> {
+		if (!hasValidHost(req)) return sendJsonRpcError(res, 403, "Invalid Host header");
+		if (!hasValidAuth(req, this.getToken())) return sendJsonRpcError(res, 401, "Unauthorized");
+
+		const url = req.url ?? "";
+		const path = url.split("?")[0];
+		if (path !== "/mcp") return sendJsonRpcError(res, 404, "Not found");
+
+		if (req.method === "GET" || req.method === "DELETE") {
+			return sendJsonRpcError(res, 405, "Method not allowed. This server only supports stateless POST requests.");
+		}
+		if (req.method !== "POST") {
+			return sendJsonRpcError(res, 405, "Method not allowed.");
+		}
+
+		let body: unknown;
+		try {
+			body = await readJsonBody(req);
+		} catch {
+			return sendJsonRpcError(res, 400, "Invalid JSON body");
+		}
+
+		const server = createMcpServer(this.app, this.version);
+		const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+		res.on("close", () => {
+			transport.close().catch((e) => logger.error("[MCP] Error closing transport:", e));
+			server.close().catch((e) => logger.error("[MCP] Error closing server:", e));
+		});
+		await server.connect(transport);
+		await transport.handleRequest(req, res, body);
+	}
+}

--- a/src/mcp/vaultOps.ts
+++ b/src/mcp/vaultOps.ts
@@ -1,0 +1,174 @@
+import { App, TFile } from "obsidian";
+import { guardVaultPath } from "mcp/pathGuard";
+
+export type VaultOpResult<T = string> =
+	| { success: true; result: T }
+	| { success: false; error: string };
+
+const MAX_SEARCH_RESULTS = 50;
+
+function errMessage(e: unknown): string {
+	return e instanceof Error ? e.message : String(e);
+}
+
+function withPrefix(path: string): string {
+	return path.endsWith("/") ? path : path + "/";
+}
+
+export async function listFiles(app: App, folder?: string): Promise<VaultOpResult<string[]>> {
+	let prefix: string | undefined;
+	try {
+		if (folder) prefix = withPrefix(guardVaultPath(folder));
+	} catch (e) {
+		return { success: false, error: errMessage(e) };
+	}
+
+	const files = app.vault
+		.getFiles()
+		.map(f => f.path)
+		.filter(p => !prefix || p.startsWith(prefix))
+		.sort();
+
+	return { success: true, result: files };
+}
+
+export async function readFile(app: App, path: string): Promise<VaultOpResult<string>> {
+	let guardedPath: string;
+	try {
+		guardedPath = guardVaultPath(path);
+	} catch (e) {
+		return { success: false, error: errMessage(e) };
+	}
+
+	const file = app.vault.getAbstractFileByPath(guardedPath);
+	if (!(file instanceof TFile)) return { success: false, error: `File not found: ${path}` };
+
+	try {
+		const content = await app.vault.read(file);
+		return { success: true, result: content };
+	} catch (e) {
+		return { success: false, error: `Failed to read ${path}: ${errMessage(e)}` };
+	}
+}
+
+export type SearchMatch = { path: string; line: number; excerpt: string };
+
+export async function searchVault(app: App, query: string, folder?: string): Promise<VaultOpResult<SearchMatch[]>> {
+	if (!query.trim()) return { success: false, error: "Query must not be empty" };
+
+	let prefix: string | undefined;
+	try {
+		if (folder) prefix = withPrefix(guardVaultPath(folder));
+	} catch (e) {
+		return { success: false, error: errMessage(e) };
+	}
+
+	const q = query.toLowerCase();
+	const matches: SearchMatch[] = [];
+	const files = app.vault.getMarkdownFiles().filter(f => !prefix || f.path.startsWith(prefix));
+
+	for (const file of files) {
+		if (matches.length >= MAX_SEARCH_RESULTS) break;
+		let content: string;
+		try {
+			content = await app.vault.read(file);
+		} catch {
+			continue;
+		}
+		const lines = content.split("\n");
+		for (let i = 0; i < lines.length; i++) {
+			if (matches.length >= MAX_SEARCH_RESULTS) break;
+			if (lines[i].toLowerCase().includes(q)) {
+				matches.push({ path: file.path, line: i + 1, excerpt: lines[i].trim() });
+			}
+		}
+	}
+
+	return { success: true, result: matches };
+}
+
+export async function createFile(app: App, path: string, content: string): Promise<VaultOpResult<string>> {
+	let target: string;
+	try {
+		target = guardVaultPath(path);
+	} catch (e) {
+		return { success: false, error: errMessage(e) };
+	}
+
+	if (app.vault.getAbstractFileByPath(target)) {
+		return { success: false, error: `A file already exists at ${path}` };
+	}
+
+	try {
+		const folder = target.substring(0, target.lastIndexOf("/"));
+		if (folder && !app.vault.getAbstractFileByPath(folder)) {
+			await app.vault.createFolder(folder);
+		}
+		await app.vault.create(target, content);
+		return { success: true, result: `Created ${target}` };
+	} catch (e) {
+		return { success: false, error: `Failed to create ${path}: ${errMessage(e)}` };
+	}
+}
+
+export async function editFile(app: App, path: string, content: string): Promise<VaultOpResult<string>> {
+	let guardedPath: string;
+	try {
+		guardedPath = guardVaultPath(path);
+	} catch (e) {
+		return { success: false, error: errMessage(e) };
+	}
+
+	const file = app.vault.getAbstractFileByPath(guardedPath);
+	if (!(file instanceof TFile)) return { success: false, error: `File not found: ${path}` };
+
+	try {
+		await app.vault.modify(file, content);
+		return { success: true, result: `Updated ${path}` };
+	} catch (e) {
+		return { success: false, error: `Failed to edit ${path}: ${errMessage(e)}` };
+	}
+}
+
+export async function moveFile(app: App, path: string, newPath: string): Promise<VaultOpResult<string>> {
+	let guardedSrc: string;
+	let guardedDest: string;
+	try {
+		guardedSrc = guardVaultPath(path);
+		guardedDest = guardVaultPath(newPath);
+	} catch (e) {
+		return { success: false, error: errMessage(e) };
+	}
+
+	const file = app.vault.getAbstractFileByPath(guardedSrc);
+	if (!(file instanceof TFile)) return { success: false, error: `File not found: ${path}` };
+	if (app.vault.getAbstractFileByPath(guardedDest)) {
+		return { success: false, error: `A file already exists at ${newPath}` };
+	}
+
+	try {
+		await app.fileManager.renameFile(file, guardedDest);
+		return { success: true, result: `Moved ${path} to ${newPath}` };
+	} catch (e) {
+		return { success: false, error: `Failed to move ${path}: ${errMessage(e)}` };
+	}
+}
+
+export async function deleteFile(app: App, path: string): Promise<VaultOpResult<string>> {
+	let guardedPath: string;
+	try {
+		guardedPath = guardVaultPath(path);
+	} catch (e) {
+		return { success: false, error: errMessage(e) };
+	}
+
+	const file = app.vault.getAbstractFileByPath(guardedPath);
+	if (!(file instanceof TFile)) return { success: false, error: `File not found: ${path}` };
+
+	try {
+		await app.fileManager.trashFile(file);
+		return { success: true, result: `Deleted ${path}` };
+	} catch (e) {
+		return { success: false, error: `Failed to delete ${path}: ${errMessage(e)}` };
+	}
+}

--- a/styles.css
+++ b/styles.css
@@ -3064,3 +3064,42 @@ button.llm-mic-button.llm-mic-transcribing {
 .llm-settings-wide-input {
 	width: 260px;
 }
+
+/* ── MCP Server settings ────────────────────────────────────────────────── */
+
+.llm-mcp-token-field {
+	width: 100%;
+	font-family: var(--font-monospace);
+}
+
+.llm-mcp-config-snippet {
+	user-select: text;
+	-webkit-user-select: text;
+	cursor: text;
+	background: var(--background-secondary);
+	border-radius: var(--radius-s);
+	padding: var(--size-4-2) var(--size-4-3);
+	margin: var(--size-4-2) 0;
+	font-family: var(--font-monospace);
+	font-size: var(--font-ui-smaller);
+	color: var(--text-normal);
+	white-space: pre;
+	overflow-x: auto;
+}
+
+/* MCP write-tool permission modal */
+.llm-mcp-permission-input {
+	user-select: text;
+	-webkit-user-select: text;
+	cursor: text;
+	background: var(--background-secondary);
+	border-radius: var(--radius-s);
+	padding: var(--size-4-2) var(--size-4-3);
+	margin: var(--size-4-2) 0;
+	font-family: var(--font-monospace);
+	font-size: var(--font-ui-smaller);
+	white-space: pre-wrap;
+	word-break: break-word;
+	max-height: 240px;
+	overflow-y: auto;
+}


### PR DESCRIPTION
## Summary
- Adds a built-in Streamable HTTP MCP server (127.0.0.1-only, bearer-token authenticated) so Claude Desktop or any other MCP client can read/write the vault directly, no companion plugin needed.
- Read tools (`list_files`, `read_file`, `search_vault`) run immediately; write tools (`create_file`, `edit_file`, `move_file`, `delete_file`) each require confirmation via a new permission modal before executing.
- Every path argument is resolved and validated against the vault root, rejecting traversal attempts including encoded/double-encoded `../` and absolute paths (`src/mcp/pathGuard.ts`).
- The MCP SDK and its `node:http`/`@hono/node-server` dependency chain are loaded lazily — a single `await import("mcp/transport")` in `initMcpServer()`, gated on `Platform.isDesktop && settings.mcpServerSettings.enabled` — so nothing executes at plugin load on mobile. `transport.ts`'s own `start()`/`safeCompare()` additionally self-guard with `if (!Platform.isDesktop) …` as the first statement, matching the `EmbeddingService.downloadFile()` pattern and satisfying `obsidianmd/no-nodejs-modules`.
- New settings tab (gated behind Features → MCP Server) with enable toggle, port field, bearer token display + regenerate, and a ready-to-copy `claude_desktop_config.json` snippet.
- README updated with setup instructions.

New dependencies: `@modelcontextprotocol/sdk` and `zod` (the latter was already a shared transitive dependency of `openai`/`@anthropic-ai/sdk`/`@anthropic-ai/claude-agent-sdk`, now pinned directly).

## Test plan
- [x] `npm run build`, `npm run typecheck`, `npm run lint` (`--max-warnings=0`), `npm run lint:manifest`, `npm run lint:css` all pass clean against current `main`
- [x] Headless smoke test (35 checks): path-traversal guard against 10+ payload variants, all 7 vault ops against a fake vault, HTTP auth/Host-header rejection, full real MCP protocol round-trip (`initialize` → `tools/list` → `tools/call`), a traversal attempt via real `tools/call` returns structured `isError` instead of crashing, `stop()` verified to actually release the port
- [x] Manually verified live in Obsidian: settings UI, `curl`-based auth/traversal checks against the running server, permission modal pops up and blocks a real `create_file` call until Allow/Deny
- [x] Manually verified against real Claude Desktop (via an `mcp-remote` stdio bridge, since that client only accepts `command`/`args`-style config entries): list/read/search work with no prompt, `create_file` triggers the permission modal, content round-trips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)