### PR TITLE
fix: dedicated settings modal tabs inaccessible on mobile

### DIFF
--- a/src/Settings/LLMSettingsModal.ts
+++ b/src/Settings/LLMSettingsModal.ts
@@ -173,44 +173,56 @@ export class LLMSettingsModal extends Modal {
 		const { modalEl } = this;
 		modalEl.addClass("llm-dedicated-settings-modal");
 
-		// Resolve the core settings modal element once.
-		const appSetting = (this.app as unknown as AppWithSetting).setting;
-		this.coreModalEl =
-			appSetting?.containerEl?.closest?.(".modal") ??
-			activeDocument.querySelector<HTMLElement>(".modal-container.mod-settings .modal") ??
-			Array.from(activeDocument.querySelectorAll<HTMLElement>(".modal-container .modal"))
-				.find((el) => el !== modalEl && !el.contains(modalEl)) ??
-			null;
+		// On mobile, Obsidian's core Settings UI is a single full-screen pane (no
+		// floating ".modal-container.mod-settings .modal" to match position against),
+		// and its "mod-sidebar-layout" / "vertical-tab-header" classes carry mobile-only
+		// behavior (collapsing to a single pane) that our plain Modal never wires up —
+		// borrowing them here left the sidebar permanently hidden, so only the default
+		// "General" tab was ever reachable. Use our own explicit, self-contained mobile
+		// layout instead of relying on those classes' undocumented mobile behavior.
+		if (Platform.isMobile) {
+			modalEl.addClass("llm-mobile-settings-modal");
+		} else {
+			// Resolve the core settings modal element once.
+			const appSetting = (this.app as unknown as AppWithSetting).setting;
+			this.coreModalEl =
+				appSetting?.containerEl?.closest?.(".modal") ??
+				activeDocument.querySelector<HTMLElement>(".modal-container.mod-settings .modal") ??
+				Array.from(activeDocument.querySelectorAll<HTMLElement>(".modal-container .modal"))
+					.find((el) => el !== modalEl && !el.contains(modalEl)) ??
+				null;
 
-		// Hide our scrim so we look like part of the core settings panel.
-		const modalBg = modalEl.closest(".modal-container")
-			?.querySelector<HTMLElement>(".modal-bg");
-		if (modalBg) modalBg.addClass("llm-hidden");
+			// Hide our scrim so we look like part of the core settings panel.
+			const modalBg = modalEl.closest(".modal-container")
+				?.querySelector<HTMLElement>(".modal-bg");
+			if (modalBg) modalBg.addClass("llm-hidden");
 
-		// Apply sizing now and on every window resize.
-		this.matchCoreModal();
-		this.resizeHandler = () => this.matchCoreModal();
-		window.addEventListener("resize", this.resizeHandler);
+			// Apply sizing now and on every window resize.
+			this.matchCoreModal();
+			this.resizeHandler = () => this.matchCoreModal();
+			window.addEventListener("resize", this.resizeHandler);
 
-		// Close when the user clicks outside the modal. We defer registration by
-		// one tick so the click that opened the modal doesn't immediately close it.
-		this.outsideClickHandler = (e: MouseEvent) => {
-			if (!this.modalEl.contains(e.target as Node)) {
-				this.close();
-			}
-		};
-		window.setTimeout(() => {
-			activeDocument.addEventListener("mousedown", this.outsideClickHandler!);
-		}, 0);
+			// Close when the user clicks outside the modal. We defer registration by
+			// one tick so the click that opened the modal doesn't immediately close it.
+			this.outsideClickHandler = (e: MouseEvent) => {
+				if (!this.modalEl.contains(e.target as Node)) {
+					this.close();
+				}
+			};
+			window.setTimeout(() => {
+				activeDocument.addEventListener("mousedown", this.outsideClickHandler!);
+			}, 0);
 
-		// mod-sidebar-layout tells Obsidian's CSS to apply the two-column layout.
-		modalEl.addClass("mod-sidebar-layout");
+			// mod-sidebar-layout tells Obsidian's CSS to apply the two-column layout.
+			modalEl.addClass("mod-sidebar-layout");
+		}
 
 		this.contentEl.empty();
 		// vertical-tabs-container is the flex wrapper Obsidian uses in its own settings.
 		this.contentEl.addClass("vertical-tabs-container");
 
-		// Sidebar — uses Obsidian's own vertical tab header classes.
+		// Sidebar — uses Obsidian's own vertical tab header classes. On mobile our CSS
+		// re-flows this into a horizontally-scrollable strip instead of a side column.
 		this.sidebarEl = this.contentEl.createDiv("vertical-tab-header");
 		this.buildSidebar(this.sidebarEl);
 

--- a/styles.css
+++ b/styles.css
@@ -1818,6 +1818,63 @@ button.llm-permission-allow {
 	overflow-y: auto;
 }
 
+/* ── Mobile layout ─────────────────────────────────────────────────────────
+   Obsidian's core .mod-sidebar-layout / .vertical-tab-header classes carry
+   mobile-only behavior (single-pane, JS-toggled) that this plugin's plain
+   Modal doesn't implement, so we don't rely on it here — this is a fully
+   self-contained stacked layout: a horizontally scrollable tab strip above
+   a full-width content pane. */
+.llm-dedicated-settings-modal.llm-mobile-settings-modal {
+	width: 100vw;
+	height: 100vh;
+	max-width: 100vw;
+	max-height: 100vh;
+	border-radius: 0;
+}
+
+.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tabs-container {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	overflow: hidden;
+}
+
+.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-header {
+	flex: 0 0 auto;
+	width: 100%;
+	max-width: none;
+	min-width: 0;
+	display: flex;
+	flex-direction: row;
+	overflow-x: auto;
+	overflow-y: hidden;
+	border-inline-end: none;
+	border-bottom: var(--border-width) solid var(--divider-color);
+	-webkit-overflow-scrolling: touch;
+}
+
+.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-header-group {
+	flex: 0 0 auto;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+}
+
+.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-header-group-title {
+	white-space: nowrap;
+	padding-inline-start: var(--size-4-2);
+}
+
+.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-header-group-items {
+	display: flex;
+	flex-direction: row;
+}
+
+.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-nav-item {
+	white-space: nowrap;
+	flex: 0 0 auto;
+}
+
 /* Tab section header — sits above the first setting-group card. */
 .llm-dedicated-settings-tab-header {
 	margin-bottom: var(--size-4-4);


### PR DESCRIPTION
## Summary
- Fixes #302 — on Android/iPad, the dedicated settings modal only ever showed the "General" tab; the sidebar with every other tab (including API key config) was unreachable.
- Root cause: `LLMSettingsModal` reuses Obsidian's core `mod-sidebar-layout` / `vertical-tab-header` classes to get the desktop two-column layout, but those classes carry mobile-only single-pane behavior (JS-toggled between tab list and tab content) that this plugin's plain `Modal` never implements — so the sidebar stayed permanently hidden on mobile.
- On `Platform.isMobile`, the modal now skips the desktop positioning/class logic entirely and uses a self-contained mobile layout: a horizontally scrollable tab strip above a full-width content pane, styled independently of Obsidian's undocumented mobile behavior for those classes.

## Test plan
- [x] `npm run build` (manifest check + tsc + esbuild) passes
- [x] `npm run lint` passes with zero warnings
- [x] `npm run lint:css` passes (no `!important` introduced)
- [ ] Manual verification on Android/iPad (needs on-device testing — flagging for beta tester confirmation per the maintainer's comment on #302)

🤖 Generated with [Claude Code](https://claude.com/claude-code)