### PR TITLE
fix: mobile settings nav as vertical drill-down list

### DIFF
--- a/src/Settings/LLMSettingsModal.ts
+++ b/src/Settings/LLMSettingsModal.ts
@@ -139,6 +139,8 @@ export class LLMSettingsModal extends Modal {
 	private resizeHandler: (() => void) | null = null;
 	private outsideClickHandler: ((e: MouseEvent) => void) | null = null;
 	private sidebarEl: HTMLElement | null = null;
+	private mobileHeaderEl: HTMLElement | null = null;
+	private mobileHeaderTitleEl: HTMLElement | null = null;
 
 	constructor(app: App, plugin: LLMPlugin, fab: FAB) {
 		super(app);
@@ -222,14 +224,42 @@ export class LLMSettingsModal extends Modal {
 		this.contentEl.addClass("vertical-tabs-container");
 
 		// Sidebar — uses Obsidian's own vertical tab header classes. On mobile our CSS
-		// re-flows this into a horizontally-scrollable strip instead of a side column.
+		// re-flows this into a full-width vertical list of cards (grouped, tappable rows)
+		// and JS drives single-pane navigation: tapping a row swaps to its content, with
+		// a back button to return to the list — there's no room for list + content side
+		// by side on a phone screen.
 		this.sidebarEl = this.contentEl.createDiv("vertical-tab-header");
 		this.buildSidebar(this.sidebarEl);
 
 		// Content area — Obsidian's classes handle layout, scrolling, and padding.
 		const contentContainer = this.contentEl.createDiv("vertical-tab-content-container");
+		if (Platform.isMobile) {
+			this.mobileHeaderEl = contentContainer.createDiv("llm-mobile-settings-header");
+			const backBtn = this.mobileHeaderEl.createDiv({ cls: "llm-mobile-settings-back tappable" });
+			const backIconEl = backBtn.createDiv("llm-mobile-settings-back-icon");
+			setIcon(backIconEl, "chevron-left");
+			backBtn.createSpan({ text: "Settings", cls: "llm-mobile-settings-back-label" });
+			backBtn.addEventListener("click", () => this.showMobileList());
+			this.mobileHeaderTitleEl = this.mobileHeaderEl.createDiv({ cls: "llm-mobile-settings-header-title" });
+			// Start on the tab list — jumping straight into "General" content left users
+			// unable to discover the other tabs at all (the bug this whole layout fixes).
+			this.contentEl.addClass("llm-mobile-view-list");
+		}
 		this.mainContentEl = contentContainer.createDiv("vertical-tab-content");
 		this.renderTab(this.activeTab);
+	}
+
+	/** Mobile only: swap the single-pane view from the tab list to the active tab's content. */
+	private showMobileDetail(label: string) {
+		if (this.mobileHeaderTitleEl) this.mobileHeaderTitleEl.setText(label);
+		this.contentEl.removeClass("llm-mobile-view-list");
+		this.contentEl.addClass("llm-mobile-view-detail");
+	}
+
+	/** Mobile only: swap the single-pane view back to the tab list. */
+	private showMobileList() {
+		this.contentEl.removeClass("llm-mobile-view-detail");
+		this.contentEl.addClass("llm-mobile-view-list");
 	}
 
 	onClose() {
@@ -275,7 +305,13 @@ export class LLMSettingsModal extends Modal {
 					setIcon(iconEl, item.icon);
 				}
 
-				itemEl.createSpan({ text: item.label });
+				itemEl.createSpan({ text: item.label, cls: "vertical-tab-nav-item-label" });
+
+				// Drill-down affordance — only meaningful on mobile's single-pane list.
+				if (Platform.isMobile) {
+					const chevronEl = itemEl.createDiv("vertical-tab-nav-item-chevron");
+					setIcon(chevronEl, "chevron-right");
+				}
 
 				itemEl.addEventListener("click", () => {
 					sidebar
@@ -284,6 +320,7 @@ export class LLMSettingsModal extends Modal {
 					itemEl.addClass("is-active");
 					this.activeTab = item.id;
 					this.renderTab(item.id);
+					if (Platform.isMobile) this.showMobileDetail(item.label);
 				});
 			}
 		}

--- a/styles.css
+++ b/styles.css
@@ -1822,8 +1822,11 @@ button.llm-permission-allow {
    Obsidian's core .mod-sidebar-layout / .vertical-tab-header classes carry
    mobile-only behavior (single-pane, JS-toggled) that this plugin's plain
    Modal doesn't implement, so we don't rely on it here — this is a fully
-   self-contained stacked layout: a horizontally scrollable tab strip above
-   a full-width content pane. */
+   self-contained single-pane layout: a full-width vertical list of grouped,
+   tappable rows (list state), and JS (showMobileDetail/showMobileList in
+   LLMSettingsModal.ts) swaps to the tab's content with a back button
+   (detail state). There's no room for list + content side by side on a
+   phone screen. */
 .llm-dedicated-settings-modal.llm-mobile-settings-modal {
 	width: 100vw;
 	height: 100vh;
@@ -1839,40 +1842,136 @@ button.llm-permission-allow {
 	overflow: hidden;
 }
 
+/* List state (default): show the tab list, hide the content pane. */
+.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tabs-container.llm-mobile-view-list .vertical-tab-content-container {
+	display: none;
+}
+
+/* Detail state: hide the tab list, show the content pane. */
+.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tabs-container.llm-mobile-view-detail .vertical-tab-header {
+	display: none;
+}
+
 .llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-header {
-	flex: 0 0 auto;
+	flex: 1 1 auto;
 	width: 100%;
 	max-width: none;
 	min-width: 0;
-	display: flex;
-	flex-direction: row;
-	overflow-x: auto;
-	overflow-y: hidden;
+	overflow-x: hidden;
+	overflow-y: auto;
 	border-inline-end: none;
-	border-bottom: var(--border-width) solid var(--divider-color);
+	padding: var(--size-4-4);
 	-webkit-overflow-scrolling: touch;
 }
 
 .llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-header-group {
-	flex: 0 0 auto;
-	display: flex;
-	flex-direction: row;
-	align-items: center;
+	margin-bottom: var(--size-4-6);
+}
+
+.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-header-group:last-child {
+	margin-bottom: 0;
 }
 
 .llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-header-group-title {
-	white-space: nowrap;
-	padding-inline-start: var(--size-4-2);
+	font-size: var(--font-ui-small);
+	font-weight: var(--font-medium);
+	color: var(--text-muted);
+	padding: 0 var(--size-4-1) var(--size-4-2);
 }
 
+/* Card — rows grouped into a single rounded container per section. */
 .llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-header-group-items {
 	display: flex;
-	flex-direction: row;
+	flex-direction: column;
+	background-color: var(--background-secondary);
+	border-radius: var(--radius-l);
+	overflow: hidden;
 }
 
 .llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-nav-item {
+	display: flex;
+	align-items: center;
+	gap: var(--size-4-3);
+	padding: var(--size-4-3) var(--size-4-4);
+}
+
+.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-nav-item:not(:first-child) {
+	border-top: var(--border-width) solid var(--background-modifier-border);
+}
+
+.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-nav-item-icon {
+	display: flex;
+	align-items: center;
+	color: var(--text-muted);
+}
+
+.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-nav-item-icon svg {
+	width: var(--icon-m);
+	height: var(--icon-m);
+}
+
+.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-nav-item-label {
+	flex: 1;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-nav-item-chevron {
+	display: flex;
+	align-items: center;
 	flex: 0 0 auto;
+	color: var(--text-faint);
+}
+
+.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-nav-item-chevron svg {
+	width: var(--icon-s);
+	height: var(--icon-s);
+}
+
+/* Detail-state header: sticky back button + current tab title above content. */
+.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-content-container {
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-content {
+	flex: 1;
+	min-height: 0;
+	overflow-y: auto;
+}
+
+.llm-mobile-settings-header {
+	display: flex;
+	align-items: center;
+	gap: var(--size-4-3);
+	padding: var(--size-4-3) var(--size-4-4);
+	border-bottom: var(--border-width) solid var(--background-modifier-border);
+	flex: 0 0 auto;
+}
+
+.llm-mobile-settings-back {
+	display: flex;
+	align-items: center;
+	gap: var(--size-4-1);
+	color: var(--text-accent);
+	flex: 0 0 auto;
+}
+
+.llm-mobile-settings-back-icon svg {
+	width: var(--icon-m);
+	height: var(--icon-m);
+}
+
+.llm-mobile-settings-header-title {
+	font-weight: var(--font-semibold);
+	font-size: var(--font-ui-medium);
+	color: var(--text-normal);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 /* Tab section header — sits above the first setting-group card. */


### PR DESCRIPTION
## Summary
- Follow-up to #303 (mobile settings tabs fix). The horizontally-scrollable tab strip that landed there was usable but not a great mobile pattern per beta-tester feedback (screenshots from BRAT testing on-device).
- Replaces it with a full-width vertical list of grouped, tappable rows (icon + label + chevron, matching common Obsidian-plugin mobile settings patterns) that drills down into the tab's content with a back button, since a phone screen doesn't have room for list + content side by side.

## Test plan
- [x] `npm run build` (manifest check + tsc + esbuild) passes
- [x] `npm run lint` passes with zero warnings
- [x] `npm run lint:css` passes (no `!important` introduced)
- [ ] Manual on-device verification (Android/iPad via BRAT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)