### PR TITLE
fix: mobile settings modal chrome (close-button overlap, stray border)

### DIFF
--- a/src/Settings/LLMSettingsModal.ts
+++ b/src/Settings/LLMSettingsModal.ts
@@ -175,6 +175,13 @@ export class LLMSettingsModal extends Modal {
 		const { modalEl } = this;
 		modalEl.addClass("llm-dedicated-settings-modal");
 
+		// Hide our own scrim in both layouts: on desktop so we look like part of the
+		// core settings panel we're pinned against, on mobile so nothing shows through
+		// the full-bleed modal's edges.
+		const modalBg = modalEl.closest(".modal-container")
+			?.querySelector<HTMLElement>(".modal-bg");
+		if (modalBg) modalBg.addClass("llm-hidden");
+
 		// On mobile, Obsidian's core Settings UI is a single full-screen pane (no
 		// floating ".modal-container.mod-settings .modal" to match position against),
 		// and its "mod-sidebar-layout" / "vertical-tab-header" classes carry mobile-only
@@ -193,11 +200,6 @@ export class LLMSettingsModal extends Modal {
 				Array.from(activeDocument.querySelectorAll<HTMLElement>(".modal-container .modal"))
 					.find((el) => el !== modalEl && !el.contains(modalEl)) ??
 				null;
-
-			// Hide our scrim so we look like part of the core settings panel.
-			const modalBg = modalEl.closest(".modal-container")
-				?.querySelector<HTMLElement>(".modal-bg");
-			if (modalBg) modalBg.addClass("llm-hidden");
 
 			// Apply sizing now and on every window resize.
 			this.matchCoreModal();
@@ -223,28 +225,34 @@ export class LLMSettingsModal extends Modal {
 		// vertical-tabs-container is the flex wrapper Obsidian uses in its own settings.
 		this.contentEl.addClass("vertical-tabs-container");
 
+		// Mobile: a persistent header bar sits above both the list and the content pane
+		// (not just the content pane) so there's always room reserved below Obsidian's
+		// own close button and the status bar/notch — without it, the tab list rendered
+		// flush against the top edge and visually collided with the close button.
+		if (Platform.isMobile) {
+			this.mobileHeaderEl = this.contentEl.createDiv("llm-mobile-settings-header");
+			const backBtn = this.mobileHeaderEl.createDiv({ cls: "llm-mobile-settings-back tappable" });
+			const backIconEl = backBtn.createDiv("llm-mobile-settings-back-icon");
+			setIcon(backIconEl, "chevron-left");
+			backBtn.createSpan({ text: "Back", cls: "llm-mobile-settings-back-label" });
+			backBtn.addEventListener("click", () => this.showMobileList());
+			this.mobileHeaderTitleEl = this.mobileHeaderEl.createDiv({ cls: "llm-mobile-settings-header-title" });
+			this.mobileHeaderTitleEl.setText(this.plugin.manifest.name);
+			// Start on the tab list — jumping straight into "General" content left users
+			// unable to discover the other tabs at all (the bug this whole layout fixes).
+			this.contentEl.addClass("llm-mobile-view-list");
+		}
+
 		// Sidebar — uses Obsidian's own vertical tab header classes. On mobile our CSS
 		// re-flows this into a full-width vertical list of cards (grouped, tappable rows)
 		// and JS drives single-pane navigation: tapping a row swaps to its content, with
-		// a back button to return to the list — there's no room for list + content side
-		// by side on a phone screen.
+		// the header's back button returning to the list — there's no room for list +
+		// content side by side on a phone screen.
 		this.sidebarEl = this.contentEl.createDiv("vertical-tab-header");
 		this.buildSidebar(this.sidebarEl);
 
 		// Content area — Obsidian's classes handle layout, scrolling, and padding.
 		const contentContainer = this.contentEl.createDiv("vertical-tab-content-container");
-		if (Platform.isMobile) {
-			this.mobileHeaderEl = contentContainer.createDiv("llm-mobile-settings-header");
-			const backBtn = this.mobileHeaderEl.createDiv({ cls: "llm-mobile-settings-back tappable" });
-			const backIconEl = backBtn.createDiv("llm-mobile-settings-back-icon");
-			setIcon(backIconEl, "chevron-left");
-			backBtn.createSpan({ text: "Settings", cls: "llm-mobile-settings-back-label" });
-			backBtn.addEventListener("click", () => this.showMobileList());
-			this.mobileHeaderTitleEl = this.mobileHeaderEl.createDiv({ cls: "llm-mobile-settings-header-title" });
-			// Start on the tab list — jumping straight into "General" content left users
-			// unable to discover the other tabs at all (the bug this whole layout fixes).
-			this.contentEl.addClass("llm-mobile-view-list");
-		}
 		this.mainContentEl = contentContainer.createDiv("vertical-tab-content");
 		this.renderTab(this.activeTab);
 	}
@@ -258,6 +266,7 @@ export class LLMSettingsModal extends Modal {
 
 	/** Mobile only: swap the single-pane view back to the tab list. */
 	private showMobileList() {
+		if (this.mobileHeaderTitleEl) this.mobileHeaderTitleEl.setText(this.plugin.manifest.name);
 		this.contentEl.removeClass("llm-mobile-view-detail");
 		this.contentEl.addClass("llm-mobile-view-list");
 	}

--- a/styles.css
+++ b/styles.css
@@ -1828,10 +1828,18 @@ button.llm-permission-allow {
    (detail state). There's no room for list + content side by side on a
    phone screen. */
 .llm-dedicated-settings-modal.llm-mobile-settings-modal {
-	width: 100vw;
-	height: 100vh;
-	max-width: 100vw;
-	max-height: 100vh;
+	/* position:fixed + inset:0 covers the true viewport edge-to-edge regardless of
+	   the core .modal-container's own centering/padding — width/height:100vw/100vh
+	   alone left a gap where that centering showed through as a stray border. */
+	position: fixed;
+	inset: 0;
+	width: auto;
+	height: auto;
+	max-width: none;
+	max-height: none;
+	margin: 0;
+	border: none;
+	box-shadow: none;
 	border-radius: 0;
 }
 
@@ -1930,26 +1938,27 @@ button.llm-permission-allow {
 	height: var(--icon-s);
 }
 
-/* Detail-state header: sticky back button + current tab title above content. */
-.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-content-container {
-	display: flex;
-	flex-direction: column;
-	overflow: hidden;
-}
-
-.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-content {
-	flex: 1;
-	min-height: 0;
-	overflow-y: auto;
-}
-
+/* Persistent header — sits above both the list and the content pane (a sibling of
+   both in .vertical-tabs-container, not nested in .vertical-tab-content-container),
+   so there's always room reserved below the status bar/notch and to the left of
+   Obsidian's own close (✕) button, in both list and detail states. */
 .llm-mobile-settings-header {
 	display: flex;
 	align-items: center;
 	gap: var(--size-4-3);
-	padding: var(--size-4-3) var(--size-4-4);
-	border-bottom: var(--border-width) solid var(--background-modifier-border);
 	flex: 0 0 auto;
+	padding: var(--size-4-3) var(--size-4-4);
+	/* Obsidian's own modal close button floats top-right at a fixed size we don't
+	   control — reserve enough end padding that our title never runs under it. */
+	padding-inline-end: calc(var(--size-4-4) + 56px);
+	padding-top: calc(var(--size-4-3) + env(safe-area-inset-top));
+	padding-inline-start: calc(var(--size-4-4) + env(safe-area-inset-left));
+	border-bottom: var(--border-width) solid var(--background-modifier-border);
+}
+
+/* No parent to go back to while on the root list. */
+.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tabs-container.llm-mobile-view-list .llm-mobile-settings-back {
+	display: none;
 }
 
 .llm-mobile-settings-back {
@@ -1966,12 +1975,23 @@ button.llm-permission-allow {
 }
 
 .llm-mobile-settings-header-title {
+	flex: 1;
+	min-width: 0;
 	font-weight: var(--font-semibold);
 	font-size: var(--font-ui-medium);
 	color: var(--text-normal);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+/* Bottom safe-area clearance (home-indicator strip) for the two scrollable panes. */
+.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-header {
+	padding-bottom: calc(var(--size-4-4) + env(safe-area-inset-bottom));
+}
+
+.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-content-container {
+	padding-bottom: env(safe-area-inset-bottom);
 }
 
 /* Tab section header — sits above the first setting-group card. */


### PR DESCRIPTION
## Summary
Follow-up to #302 / 0.24.26. Beta-tester screenshots (on-device, compared against core Obsidian's own mobile Settings) showed two chrome issues:

1. **Close button overlap** — the tab-list state had no header/top padding reserved at all (only the content/detail pane had a header bar), so the list rendered flush against the top edge and collided with Obsidian's own close (✕) button. The header is now a persistent sibling of both the list and content panes — always visible, with a back button that's hidden while on the root list (nothing to go back to there) and enough end-padding reserved to clear the close button.
2. **Stray dark border around the modal** — caused by forcing `width/height: 100vw/100vh` while the core `.modal-container`'s own centering and the base `.modal`'s default border/box-shadow (`--modal-border-width`/`--modal-border-color`, confirmed via Obsidian's [CSS variable docs](https://docs.obsidian.md/Reference/CSS+variables/Components/Modal)) still applied underneath. Obsidian's changelog notes modals already respect safe-area-insets without extra CSS, so the fix is to stop fighting that: `position: fixed; inset: 0;` covers the true viewport regardless of the container's box model, with `border`/`box-shadow`/`margin` explicitly zeroed for our full-bleed mobile modal.

Also added `env(safe-area-inset-*)` padding (top/bottom/left) throughout so content clears the notch/status bar and home-indicator strip.

## Test plan
- [x] `npm run build` (manifest check + tsc + esbuild) passes
- [x] `npm run lint` passes with zero warnings
- [x] `npm run lint:css` passes (no `!important` introduced)
- [ ] Manual on-device verification (Android/iPad via BRAT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)