### PR TITLE
fix: use Obsidian's real mod-settings class for mobile settings chrome

### DIFF
--- a/src/Settings/LLMSettingsModal.ts
+++ b/src/Settings/LLMSettingsModal.ts
@@ -139,8 +139,6 @@ export class LLMSettingsModal extends Modal {
 	private resizeHandler: (() => void) | null = null;
 	private outsideClickHandler: ((e: MouseEvent) => void) | null = null;
 	private sidebarEl: HTMLElement | null = null;
-	private mobileHeaderEl: HTMLElement | null = null;
-	private mobileHeaderTitleEl: HTMLElement | null = null;
 
 	constructor(app: App, plugin: LLMPlugin, fab: FAB) {
 		super(app);
@@ -182,14 +180,20 @@ export class LLMSettingsModal extends Modal {
 			?.querySelector<HTMLElement>(".modal-bg");
 		if (modalBg) modalBg.addClass("llm-hidden");
 
-		// On mobile, Obsidian's core Settings UI is a single full-screen pane (no
-		// floating ".modal-container.mod-settings .modal" to match position against),
-		// and its "mod-sidebar-layout" / "vertical-tab-header" classes carry mobile-only
-		// behavior (collapsing to a single pane) that our plain Modal never wires up —
-		// borrowing them here left the sidebar permanently hidden, so only the default
-		// "General" tab was ever reachable. Use our own explicit, self-contained mobile
-		// layout instead of relying on those classes' undocumented mobile behavior.
+		// On mobile, opt into Obsidian's own real Settings-modal chrome ("mod-settings")
+		// instead of hand-rolling it: this is what gives correct full-screen sizing,
+		// safe-area handling, a borderless edge-to-edge look, and clearance around
+		// Obsidian's own close button "for free" from core CSS — confirmed by checking
+		// how another plugin (Task Genius) does the exact same multi-tab-in-one-modal
+		// settings pattern. Hand-rolled attempts at this never quite matched core's
+		// actual behavior because we were guessing at values core already knows.
+		// Desktop keeps its existing matchCoreModal() pinning below untouched — adding
+		// "mod-settings" there too risks core's own sizing rules outranking ours.
 		if (Platform.isMobile) {
+			modalEl.addClass("mod-settings");
+			modalEl.addClass("mod-sidebar-layout");
+			// Scoping hook for the small amount of CSS that's still ours to own (the
+			// list/detail single-pane toggle) — mod-settings supplies everything else.
 			modalEl.addClass("llm-mobile-settings-modal");
 		} else {
 			// Resolve the core settings modal element once.
@@ -225,29 +229,11 @@ export class LLMSettingsModal extends Modal {
 		// vertical-tabs-container is the flex wrapper Obsidian uses in its own settings.
 		this.contentEl.addClass("vertical-tabs-container");
 
-		// Mobile: a persistent header bar sits above both the list and the content pane
-		// (not just the content pane) so there's always room reserved below Obsidian's
-		// own close button and the status bar/notch — without it, the tab list rendered
-		// flush against the top edge and visually collided with the close button.
-		if (Platform.isMobile) {
-			this.mobileHeaderEl = this.contentEl.createDiv("llm-mobile-settings-header");
-			const backBtn = this.mobileHeaderEl.createDiv({ cls: "llm-mobile-settings-back tappable" });
-			const backIconEl = backBtn.createDiv("llm-mobile-settings-back-icon");
-			setIcon(backIconEl, "chevron-left");
-			backBtn.createSpan({ text: "Back", cls: "llm-mobile-settings-back-label" });
-			backBtn.addEventListener("click", () => this.showMobileList());
-			this.mobileHeaderTitleEl = this.mobileHeaderEl.createDiv({ cls: "llm-mobile-settings-header-title" });
-			this.mobileHeaderTitleEl.setText(this.plugin.manifest.name);
-			// Start on the tab list — jumping straight into "General" content left users
-			// unable to discover the other tabs at all (the bug this whole layout fixes).
-			this.contentEl.addClass("llm-mobile-view-list");
-		}
-
-		// Sidebar — uses Obsidian's own vertical tab header classes. On mobile our CSS
-		// re-flows this into a full-width vertical list of cards (grouped, tappable rows)
-		// and JS drives single-pane navigation: tapping a row swaps to its content, with
-		// the header's back button returning to the list — there's no room for list +
-		// content side by side on a phone screen.
+		// Sidebar — uses Obsidian's own vertical tab header classes. On mobile, "mod-settings"
+		// (added above) re-flows this into the native full-width vertical list; JS drives
+		// single-pane navigation on top of that: tapping a row swaps to its content, with
+		// this.titleEl (the Modal's own title bar, already correctly positioned clear of
+		// the close button and safe areas) repurposed as a back-navigation header.
 		this.sidebarEl = this.contentEl.createDiv("vertical-tab-header");
 		this.buildSidebar(this.sidebarEl);
 
@@ -255,20 +241,44 @@ export class LLMSettingsModal extends Modal {
 		const contentContainer = this.contentEl.createDiv("vertical-tab-content-container");
 		this.mainContentEl = contentContainer.createDiv("vertical-tab-content");
 		this.renderTab(this.activeTab);
+
+		if (Platform.isMobile) {
+			// Start on the tab list — jumping straight into "General" content left users
+			// unable to discover the other tabs at all (the bug this whole layout fixes).
+			this.contentEl.addClass("llm-mobile-view-list");
+			this.renderMobileTitle(null);
+		}
+	}
+
+	/**
+	 * Mobile only: renders this.titleEl (the Modal's own title bar) either as the plugin
+	 * name (list state, nothing to go back to) or a back button + the active tab's label
+	 * (detail state) — reusing Obsidian's own back-button class so it matches core exactly.
+	 */
+	private renderMobileTitle(detailLabel: string | null) {
+		this.titleEl.empty();
+		if (detailLabel) {
+			const backBtn = this.titleEl.createDiv({ cls: "clickable-icon modal-setting-back-button" });
+			setIcon(backBtn, "arrow-left");
+			backBtn.addEventListener("click", () => this.showMobileList());
+			this.titleEl.createSpan({ text: detailLabel });
+		} else {
+			this.titleEl.createSpan({ text: this.plugin.manifest.name });
+		}
 	}
 
 	/** Mobile only: swap the single-pane view from the tab list to the active tab's content. */
 	private showMobileDetail(label: string) {
-		if (this.mobileHeaderTitleEl) this.mobileHeaderTitleEl.setText(label);
 		this.contentEl.removeClass("llm-mobile-view-list");
 		this.contentEl.addClass("llm-mobile-view-detail");
+		this.renderMobileTitle(label);
 	}
 
 	/** Mobile only: swap the single-pane view back to the tab list. */
 	private showMobileList() {
-		if (this.mobileHeaderTitleEl) this.mobileHeaderTitleEl.setText(this.plugin.manifest.name);
 		this.contentEl.removeClass("llm-mobile-view-detail");
 		this.contentEl.addClass("llm-mobile-view-list");
+		this.renderMobileTitle(null);
 	}
 
 	onClose() {
@@ -314,7 +324,10 @@ export class LLMSettingsModal extends Modal {
 					setIcon(iconEl, item.icon);
 				}
 
-				itemEl.createSpan({ text: item.label, cls: "vertical-tab-nav-item-label" });
+				// vertical-tab-nav-item-title matches core's own class for this element
+				// (confirmed against Task Genius's settings modal, which relies on core
+				// CSS for it entirely rather than styling it themselves).
+				itemEl.createSpan({ text: item.label, cls: "vertical-tab-nav-item-title" });
 
 				// Drill-down affordance — only meaningful on mobile's single-pane list.
 				if (Platform.isMobile) {

--- a/styles.css
+++ b/styles.css
@@ -1819,179 +1819,24 @@ button.llm-permission-allow {
 }
 
 /* ── Mobile layout ─────────────────────────────────────────────────────────
-   Obsidian's core .mod-sidebar-layout / .vertical-tab-header classes carry
-   mobile-only behavior (single-pane, JS-toggled) that this plugin's plain
-   Modal doesn't implement, so we don't rely on it here — this is a fully
-   self-contained single-pane layout: a full-width vertical list of grouped,
-   tappable rows (list state), and JS (showMobileDetail/showMobileList in
-   LLMSettingsModal.ts) swaps to the tab's content with a back button
-   (detail state). There's no room for list + content side by side on a
-   phone screen. */
-.llm-dedicated-settings-modal.llm-mobile-settings-modal {
-	/* position:fixed + inset:0 covers the true viewport edge-to-edge regardless of
-	   the core .modal-container's own centering/padding — width/height:100vw/100vh
-	   alone left a gap where that centering showed through as a stray border. */
-	position: fixed;
-	inset: 0;
-	width: auto;
-	height: auto;
-	max-width: none;
-	max-height: none;
-	margin: 0;
-	border: none;
-	box-shadow: none;
-	border-radius: 0;
-}
-
-.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tabs-container {
-	display: flex;
-	flex-direction: column;
-	height: 100%;
-	overflow: hidden;
-}
+   modalEl also gets Obsidian's own "mod-settings" class on mobile (see
+   LLMSettingsModal.ts onOpen) — that's what gives correct full-screen sizing,
+   safe-area handling, a borderless look, and close-button clearance, all from
+   core CSS. Hand-rolling those in this plugin's own CSS (earlier attempts)
+   never quite matched core's real behavior. The one thing "mod-settings"
+   doesn't provide — because it's specific to this plugin's own multi-tab
+   layout, not something core needs to solve — is swapping between the tab
+   list and a tab's content as a single pane on a phone-width screen. That's
+   the only mobile-specific CSS left here. */
 
 /* List state (default): show the tab list, hide the content pane. */
-.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tabs-container.llm-mobile-view-list .vertical-tab-content-container {
+.llm-mobile-settings-modal .vertical-tabs-container.llm-mobile-view-list .vertical-tab-content-container {
 	display: none;
 }
 
 /* Detail state: hide the tab list, show the content pane. */
-.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tabs-container.llm-mobile-view-detail .vertical-tab-header {
+.llm-mobile-settings-modal .vertical-tabs-container.llm-mobile-view-detail .vertical-tab-header {
 	display: none;
-}
-
-.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-header {
-	flex: 1 1 auto;
-	width: 100%;
-	max-width: none;
-	min-width: 0;
-	overflow-x: hidden;
-	overflow-y: auto;
-	border-inline-end: none;
-	padding: var(--size-4-4);
-	-webkit-overflow-scrolling: touch;
-}
-
-.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-header-group {
-	margin-bottom: var(--size-4-6);
-}
-
-.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-header-group:last-child {
-	margin-bottom: 0;
-}
-
-.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-header-group-title {
-	font-size: var(--font-ui-small);
-	font-weight: var(--font-medium);
-	color: var(--text-muted);
-	padding: 0 var(--size-4-1) var(--size-4-2);
-}
-
-/* Card — rows grouped into a single rounded container per section. */
-.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-header-group-items {
-	display: flex;
-	flex-direction: column;
-	background-color: var(--background-secondary);
-	border-radius: var(--radius-l);
-	overflow: hidden;
-}
-
-.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-nav-item {
-	display: flex;
-	align-items: center;
-	gap: var(--size-4-3);
-	padding: var(--size-4-3) var(--size-4-4);
-}
-
-.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-nav-item:not(:first-child) {
-	border-top: var(--border-width) solid var(--background-modifier-border);
-}
-
-.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-nav-item-icon {
-	display: flex;
-	align-items: center;
-	color: var(--text-muted);
-}
-
-.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-nav-item-icon svg {
-	width: var(--icon-m);
-	height: var(--icon-m);
-}
-
-.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-nav-item-label {
-	flex: 1;
-	min-width: 0;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
-.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-nav-item-chevron {
-	display: flex;
-	align-items: center;
-	flex: 0 0 auto;
-	color: var(--text-faint);
-}
-
-.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-nav-item-chevron svg {
-	width: var(--icon-s);
-	height: var(--icon-s);
-}
-
-/* Persistent header — sits above both the list and the content pane (a sibling of
-   both in .vertical-tabs-container, not nested in .vertical-tab-content-container),
-   so there's always room reserved below the status bar/notch and to the left of
-   Obsidian's own close (✕) button, in both list and detail states. */
-.llm-mobile-settings-header {
-	display: flex;
-	align-items: center;
-	gap: var(--size-4-3);
-	flex: 0 0 auto;
-	padding: var(--size-4-3) var(--size-4-4);
-	/* Obsidian's own modal close button floats top-right at a fixed size we don't
-	   control — reserve enough end padding that our title never runs under it. */
-	padding-inline-end: calc(var(--size-4-4) + 56px);
-	padding-top: calc(var(--size-4-3) + env(safe-area-inset-top));
-	padding-inline-start: calc(var(--size-4-4) + env(safe-area-inset-left));
-	border-bottom: var(--border-width) solid var(--background-modifier-border);
-}
-
-/* No parent to go back to while on the root list. */
-.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tabs-container.llm-mobile-view-list .llm-mobile-settings-back {
-	display: none;
-}
-
-.llm-mobile-settings-back {
-	display: flex;
-	align-items: center;
-	gap: var(--size-4-1);
-	color: var(--text-accent);
-	flex: 0 0 auto;
-}
-
-.llm-mobile-settings-back-icon svg {
-	width: var(--icon-m);
-	height: var(--icon-m);
-}
-
-.llm-mobile-settings-header-title {
-	flex: 1;
-	min-width: 0;
-	font-weight: var(--font-semibold);
-	font-size: var(--font-ui-medium);
-	color: var(--text-normal);
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
-
-/* Bottom safe-area clearance (home-indicator strip) for the two scrollable panes. */
-.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-header {
-	padding-bottom: calc(var(--size-4-4) + env(safe-area-inset-bottom));
-}
-
-.llm-dedicated-settings-modal.llm-mobile-settings-modal .vertical-tab-content-container {
-	padding-bottom: env(safe-area-inset-bottom);
 }
 
 /* Tab section header — sits above the first setting-group card. */


### PR DESCRIPTION
## Summary
Previous mobile fixes (0.24.26, 0.24.27) hand-rolled full-screen sizing, safe-area padding, borders, and a custom header bar to approximate core Obsidian's mobile Settings look — beta-tester feedback was it still didn't match (close-button overlap, stray border persisted).

Checked how [Task Genius](https://github.com/taskgenius/taskgenius-plugin) solves the same problem (a custom Modal with the same multi-tab-in-one-modal settings pattern, working correctly on mobile): it adds Obsidian's **real** `mod-settings` class to its Modal. Their own custom `.vertical-tab-header`/`.vertical-tab-nav-item`/chevron CSS exists in their SCSS but is entirely commented out/dead — they rely on core CSS for all of it. The one thing core doesn't provide (specific to a multi-tab custom modal) is swapping between the tab list and a tab's content as a single pane; they reuse the Modal's own `titleEl` for that back-navigation header via Obsidian's own `modal-setting-back-button` class rather than building one from scratch.

This PR does the same:
- `modalEl` gets `mod-settings` on **mobile only** — desktop keeps its existing `matchCoreModal()` pinning untouched, since adding `mod-settings` there risks core's own sizing rules (higher specificity) outranking our pinned position/size.
- `this.titleEl` (the Modal's own title bar, always correctly positioned clear of the close button and safe areas) is repurposed as the back-navigation header, instead of a hand-rolled one.
- Net effect: ~140 lines of guessed-at CSS deleted in favor of the real thing from core.

## Test plan
- [x] `npm run build` (manifest check + tsc + esbuild) passes
- [x] `npm run lint` passes with zero warnings
- [x] `npm run lint:css` passes (no `!important` introduced)
- [ ] Manual on-device verification (Android/iPad via BRAT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)