### PR TITLE
fix: prevent horizontal scroll in mobile settings sub-pages

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1839,6 +1839,21 @@ button.llm-permission-allow {
 	display: none;
 }
 
+/* Dropdowns whose options are long (e.g. Ollama/LM Studio model names pulled from
+   Hugging Face repo paths) can make an unconstrained <select> size itself to its
+   widest option on iOS instead of respecting the container width, dragging the
+   whole page into horizontal scroll. Clamp every dropdown to the content width and
+   back it up with overflow-x: hidden on the scroll containers as a general guard
+   against any other stray wide element doing the same thing. */
+.llm-mobile-settings-modal .vertical-tab-content-container,
+.llm-mobile-settings-modal .vertical-tab-content {
+	overflow-x: hidden;
+}
+
+.llm-mobile-settings-modal .vertical-tab-content select {
+	max-width: 100%;
+}
+
 /* Tab section header — sits above the first setting-group card. */
 .llm-dedicated-settings-tab-header {
 	margin-bottom: var(--size-4-4);


### PR DESCRIPTION
## Summary
Follow-up to #306. Beta-tester screenshot showed the settings detail pane (e.g. General tab) could be scrolled horizontally on mobile, cutting off text on both edges.

Likely cause: the "Default model or assistant" dropdown lists Ollama/LM Studio model names pulled from Hugging Face repo paths, which can be long (`hf.co/Jackrong/Qwopus3.5-9B...`). An unconstrained `<select>` can size itself to its widest option on iOS instead of respecting the container width, dragging the whole content pane into horizontal scroll.

- Clamp `select` width to the content pane on mobile.
- Add `overflow-x: hidden` on the content scroll containers as a general guard against any other stray wide element doing the same thing.

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes with zero warnings
- [x] `npm run lint:css` passes (no `!important` introduced)
- [ ] Manual on-device verification (Android/iPad via BRAT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)